### PR TITLE
Replace previous CIA 8520 core with new modular implementation

### DIFF
--- a/cia/README.md
+++ b/cia/README.md
@@ -1,12 +1,24 @@
 # CIA 8520 implementation
 
-Full CIA implementation.
-
-Initial work has been done by Niklas Ekström (https://github.com/niklasekstrom/cia-verilog).
+Original Verilog implementation was done by Niklas Ekström (https://github.com/niklasekstrom/cia-verilog).
+Cross checked with the CIA dissection (http://forum.6502.org/viewtopic.php?f=4&t=7368)
+This implementation playground is available at (https://www.edaplayground.com/x/aYYC)
 
 It has been reimplemented to offer the following features:
-- separate modules to split core logic and the I/O buffering (tri-state).
-- dual edge sensitive design (for faster signal syncs).
-- additional 'fast pulse' when timer and latch are zero.
-- serial port can be faster.
+- separate modules to split core logic from I/O buffering (tri-state handling).
+- dual-edge sensitive design (the CIA internally generates two non-overlapping clock phases).
+- optional extensions (disabled by default, enabled via spare register to preserve compatibility).
 
+The implementation is split across several modules to improve readability, verification, and maintainability. Further work will make the design more FPGA-friendly (e.g. use of a single internal FPGA clock with clock-enable signals instead of relying directly on phi2).
+
+The following modules are available:
+- [cia_top.v](cia_top.v) : CIA 8520 wrapper. This module is the verilog representation of the real chip pins including tri-state ones. It still requires external pull-ups (or equivalent FPGA I/O constraints).
+- [cia8520.v](cia8520.v) : CIA Implementation top module. It is responsible for visible register reads and writes as well as CNT/SP synchronization. 
+- [cia_decoder.v](cia_decoder.v) : Purely combinational address decoder. Selects the target register and routes enables to the appropriate submodule.
+- [cia_handshake.v](cia_handshake.v) : Implements flag interrupt pulse and PC pulse following PRB
+- [cia_interrupts.v](cia_interrupts.v) : Retrieve interrupts from submodules and generate interrupt register value 
+- [cia_serial.v](cia_serial.v) : Perform serial transfers. synchronization of CNT/SP is handled by CIA top module (not the wrapper). In input the data is made available and is transferred by the top module to the SDR register. In output, the top module signals the serial module that new data is available to be transferred. This module differs in implementation with the real CIA (real CIA uses counter for bits in/out, this version uses a stop bit in the shift register).
+- [cia_timer.v](cia_timer.v) : Timer implementation. The top module handle additional timer mechanics (autostart/autoload when writing TAHI, forceload strobe, etc...) as well as latch register
+- [cia_tod.v](cia_tod.v) : TOD latch implementation. Top module is responsible to maintain TOD counter and ALRM. This submodule only handles strobe and ALRM comparison.
+
+A test bench is provided to validate most of the features.

--- a/cia/README.md
+++ b/cia/README.md
@@ -12,7 +12,7 @@ It has been reimplemented to offer the following features:
 The implementation is split across several modules to improve readability, verification, and maintainability. Further work will make the design more FPGA-friendly (e.g. use of a single internal FPGA clock with clock-enable signals instead of relying directly on phi2).
 
 The following modules are available:
-- [cia_top.v](cia_top.v) : CIA 8520 wrapper. This module is the verilog representation of the real chip pins including tri-state ones. It still requires external pull-ups (or equivalent FPGA I/O constraints).
+- [cia8520_top.v](cia8520_top.v) : CIA 8520 wrapper. This module is the verilog representation of the real chip pins including tri-state ones. It still requires external pull-ups (or equivalent FPGA I/O constraints).
 - [cia8520.v](cia8520.v) : CIA Implementation top module. It is responsible for visible register reads and writes as well as CNT/SP synchronization. 
 - [cia_decoder.v](cia_decoder.v) : Purely combinational address decoder. Selects the target register and routes enables to the appropriate submodule.
 - [cia_handshake.v](cia_handshake.v) : Implements flag interrupt pulse and PC pulse following PRB

--- a/cia/cia8520.v
+++ b/cia/cia8520.v
@@ -1,867 +1,640 @@
 /*
  * CIA 8520 module
- * Written by Rodolphe de Saint Léger (some code from Niklas Ekström).
+ * Written by Rodolphe de Saint Léger (original code from Niklas Ekström).
  *
  * This implementation WILL NOT apply CIA undocumented features.
  *
- * Changes against CIA documented features :
+ * Changes against CIA documented features (available as extensions in spare register) :
  * - module is able of phi2 divided by 2 serial I/O (not available in original 8520)
- * - timer A/B will switch to half clock pulses if timer count and latch are both 0 and timer run continuously
+ * - cnt input can be synchronized one clock earlier
+ * - timer A/B can switch to half clock pulses if timer count and latch are both 0 and timer run continuously
+ * - reload delay when timer A/B underflows can be removed
+ *
+ * the spare register is used to enable extensions:
+ * - Bit 0 : short cnt sampling,
+ * - Bit 1 : half clk pulses on port B (only visible if fast reload enabled)
+ * - Bit 2 : fast reload (if enabled with short cnt sampling, enable fast serial as side effect)
  *
  * Design :
- * - reads are valid for one clock cycle, starting at posedge
+ * - reads are valid for one clock cycle, starting at posedge (combinatorial only)
+ *   since data must be set shortly after posedge and shortly around negedge (internal cia clock signals)
  * - writes are done on negedge,
- * - irqs are detected on negedge and delivered (or cleared) on posedge,
- * - cnt, flag, sp and ports A/B are sampled at posedge
- * - tod is sampled at negedge
- * - outputs change on negedge (cnt, ps, sp, port A/B)
+ * - irqs are detected on posedge and delivered on negedge (clear is done when releasing nCS after a read),
+ * - tod, cnt, flag, sp and ports A/B are sampled at posedge
+ * - outputs change on negedge (cnt, pc, sp, port A/B)
  * - timers decrement on posedges
- * - tod increment at negedge
- * - separate serial data register for input and output (documentation does not specify if only one register is used)
- * - counter decrement logic is inverted internally (store 0x0000 instead of 0xffff and use addition)
+ * - tod increment at negedges
+ * - single serial data/shift register for input and output (documentation does not specify if only one register is used)
  */
- module cia8520(
-  input nRES, // /RES input (active low)
-  input ECLK, // phi2 clock input
+module cia8520(
+    input nRES, // /RES input (active low)
+    input ECLK, // phi2 clock input
 
-  input        nCS, // /cs input (active low)
-  input  [3:0] RS,  // RS3-RS0 register address
-  input        RW,  // R/W input (high for read, low for write)
-  input  [7:0] DBi, // data input
-  output [7:0] DBo, // data output
+    input        nCS, // /cs input (active low)
+    input  [3:0] RS,  // RS3-RS0 register address
+    input        RW,  // R/W input (high for read, low for write)
+    input  [7:0] DBi, // data input
+    output [7:0] DBo, // data output
 
-  input  [7:0] PRAi, // port A input
-  output [7:0] PRAo, // port A output
-  output [7:0] PRAd, // port A direction
+    input  [7:0] PRAi, // port A input
+    output [7:0] PRAo, // port A output
+    output [7:0] PRAd, // port A direction
 
-  input  [7:0] PRBi, // port B input
-  output [7:0] PRBo, // port B output
-  output [7:0] PRBd, // port B direction
+    input  [7:0] PRBi, // port B input
+    output [7:0] PRBo, // port B output
+    output [7:0] PRBd, // port B direction
 
-  input      nFLAG, // /FLAG input (active low)
-  output reg nPC,   // /PC output (active low)
+    input      nFLAG, // /FLAG input (active low)
+    output reg nPC,   // /PC output (active low)
 
-  input      SPi, // serial port in
-  output reg SPo, // serial port out
-  output     SPd, // serial port direction (1 = output, 0 = input)
+    input  SPi, // serial port in
+    output SPo, // serial port out
+    output SPd, // serial port direction (1 = output, 0 = input)
 
-  input      CNTi, // cnt in
-  output reg CNTo, // cnt out
+    input      CNTi, // cnt in
+    output reg CNTo, // cnt out
 
-  input TOD, // TOD counter input
+    input TOD, // TOD counter input
 
-  output nIRQ // /IRQ output (active low)
-);
+    output nIRQ // /IRQ output (active low)
+  );
 
-localparam [3:0] REG_PRA     = 4'h0;
-localparam [3:0] REG_PRB     = 4'h1;
-localparam [3:0] REG_DDRA    = 4'h2;
-localparam [3:0] REG_DDRB    = 4'h3;
-localparam [3:0] REG_TA_LO   = 4'h4;
-localparam [3:0] REG_TA_HI   = 4'h5;
-localparam [3:0] REG_TB_LO   = 4'h6;
-localparam [3:0] REG_TB_HI   = 4'h7;
-localparam [3:0] REG_TOD_LOW = 4'h8;
-localparam [3:0] REG_TOD_MID = 4'h9;
-localparam [3:0] REG_TOD_HI  = 4'ha;
-localparam [3:0] REG_SDR     = 4'hc;
-localparam [3:0] REG_ICR     = 4'hd;
-localparam [3:0] REG_CRA     = 4'he;
-localparam [3:0] REG_CRB     = 4'hf;
+  // convert input signals to active high
+  wire rst_i = ~nRES;
+  wire sel_i = ~nCS;
+  wire we_i  = ~RW;
 
-// convert input signals to active high
-wire rst_i = ~nRES;
-wire sel_i = ~nCS;
-wire we_i  = ~RW;
+  wire adr_pra;
+  wire adr_prb;
+  wire adr_ddra;
+  wire adr_ddrb;
+  wire adr_talo;
+  wire adr_tahi;
+  wire adr_tblo;
+  wire adr_tbhi;
+  wire adr_todlo;
+  wire adr_todmi;
+  wire adr_todhi;
+  wire adr_ext;
+  wire adr_sdr;
+  wire adr_icr;
+  wire adr_cra;
+  wire adr_crb;
 
-wire adr_pra   = RS == REG_PRA;
-wire adr_prb   = RS == REG_PRB;
-wire adr_ddra  = RS == REG_DDRA;
-wire adr_ddrb  = RS == REG_DDRB;
-wire adr_talo  = RS == REG_TA_LO;
-wire adr_tahi  = RS == REG_TA_HI;
-wire adr_tblo  = RS == REG_TB_LO;
-wire adr_tbhi  = RS == REG_TB_HI;
-wire adr_todlo = RS == REG_TOD_LOW;
-wire adr_todmi = RS == REG_TOD_MID;
-wire adr_todhi = RS == REG_TOD_HI;
-wire adr_icr   = RS == REG_ICR;
-wire adr_sdr   = RS == REG_SDR;
-wire adr_cra   = RS == REG_CRA;
-wire adr_crb   = RS == REG_CRB;
+  // extensions register
 
-wire sel_cra = sel_i & adr_cra;
-wire sel_crb = sel_i & adr_crb;
+  wire sel_ext = sel_i & adr_ext;
 
-// cnt synchronization
-reg [2:0] cnt_s;
+  reg fcnt_r; // enable fast cnt sync
+  reg fste_r; // enable half pulses on port B (for timer A/B)
+  reg frle_r; // enable fast timer reload (no dead cycle on timer A/B)
 
-wire cnt_pls = ~cnt_s[2] & cnt_s[1];
-
-initial begin
-  // powerup state
-  cnt_s = 3'b0;
-end
-
-always @(posedge ECLK) begin
-  // start cnt signal sync
-  cnt_s[0] <= CNTi;
-end
-
-always @(negedge ECLK) begin
-  // end cnt signal sync and trigger pulse for 1 clock cycle
-  { cnt_s[2:1] } <= { cnt_s[1:0] };
-end
-
-// control register A
-
-reg cra_strt;
-reg cra_pbon;
-reg cra_otmd;
-reg cra_rnmd;
-reg cra_inmd;
-reg cra_spmd;
-
-assign SPd = cra_spmd;
-
-initial begin
-  // powerup state
-  cra_strt = 1'b0;
-  cra_pbon = 1'b0;
-  cra_otmd = 1'b0;
-  cra_rnmd = 1'b0;
-  cra_inmd = 1'b0;
-  cra_spmd = 1'b0;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    cra_pbon <= 1'b0;
-    cra_otmd <= 1'b0;
-    cra_rnmd <= 1'b0;
-    cra_inmd <= 1'b0;
-    cra_spmd <= 1'b0;
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      fcnt_r <= 1'b0;
+      fste_r <= 1'b0;
+      frle_r <= 1'b0;
+    end
+    else if (sel_ext & we_i)
+    begin
+      // handle write to extension register
+      fcnt_r <= DBi[0];
+      fste_r <= DBi[1];
+      frle_r <= DBi[2];
+    end
   end
-  else if (sel_cra & we_i) begin
-    // handle write to cra (except for start and force load)
-    cra_pbon <= DBi[1];
-    cra_otmd <= DBi[2];
-    cra_rnmd <= DBi[3];
-    cra_inmd <= DBi[5];
-    cra_spmd <= DBi[6];
+
+  // cnt/sp synchronization
+  reg [3:0] cnt_s;
+  reg [2:0] spi_s;
+
+  wire cnt_pls = ~cnt_s[3] & cnt_s[2];
+
+  always @(posedge ECLK)
+  begin
+    // start cnt signal sync
+    cnt_s[0] <= CNTi;
+    spi_s[0] <= SPi;
+
+    // wait one extra posedge unless fast cnt sync is enabled
+    cnt_s[1] <= fcnt_r ? CNTi : cnt_s[0];
+    spi_s[1] <= fcnt_r ? SPi : spi_s[0];
   end
-end
 
-// control register B
-
-reg       crb_strt;
-reg       crb_pbon;
-reg       crb_otmd;
-reg       crb_rnmd;
-reg [1:0] crb_inmd;
-reg       crb_alrm;
-
-initial begin
-  // powerup state
-  crb_strt = 1'b0;
-  crb_pbon = 1'b0;
-  crb_otmd = 1'b0;
-  crb_rnmd = 1'b0;
-  crb_inmd = 2'b0;
-  crb_alrm = 1'b0;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    crb_pbon <= 1'b0;
-    crb_otmd <= 1'b0;
-    crb_rnmd <= 1'b0;
-    crb_inmd <= 2'b0;
-    crb_alrm <= 1'b0;
+  always @(negedge ECLK)
+  begin
+    // end cnt signal sync and trigger pulse for 1 clock cycle
+    { cnt_s[3:2] } <= { cnt_s[2:1] };
+    spi_s[2] <= spi_s[1];
   end
-  else if (sel_crb & we_i) begin
-    // handle write to crb (except for start and force load)
-    crb_pbon <= DBi[1];
-    crb_otmd <= DBi[2];
-    crb_rnmd <= DBi[3];
-    crb_inmd <= DBi[6:5];
-    crb_alrm <= DBi[7];
+
+  // control register A
+
+  wire sel_cra = sel_i & adr_cra;
+
+  reg cra_strt;
+  reg cra_pbon;
+  reg cra_otmd;
+  reg cra_rnmd;
+  reg cra_inmd;
+  reg cra_spmd;
+
+  assign SPd = cra_spmd;
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      cra_pbon <= 1'b0;
+      cra_otmd <= 1'b0;
+      cra_rnmd <= 1'b0;
+      cra_inmd <= 1'b0;
+      cra_spmd <= 1'b0;
+    end
+    else if (sel_cra & we_i)
+    begin
+      // handle write to cra (except for start and force load)
+      cra_pbon <= DBi[1];
+      cra_otmd <= DBi[2];
+      cra_rnmd <= DBi[3];
+      cra_inmd <= DBi[5];
+      cra_spmd <= DBi[6];
+    end
   end
-end
 
-// tod synchronization
-reg [2:0] tod_s;
+  // control register B
 
-wire tod_pls = ~tod_s[2] & tod_s[1];
+  wire sel_crb = sel_i & adr_crb;
 
-initial begin
-  // powerup state
-  tod_s = 3'b0;
-end
+  reg       crb_strt;
+  reg       crb_pbon;
+  reg       crb_otmd;
+  reg       crb_rnmd;
+  reg [1:0] crb_inmd;
+  reg       crb_alrm;
 
-always @(negedge ECLK) begin
-  // start tod signal sync
-  tod_s[0] <= TOD;
-end
-
-always @(posedge ECLK) begin
-  // end tod signal sync and trigger pulse for 1 clock cycle
-  { tod_s[2:1] } <= { tod_s[1:0] };
-end
-
-reg  [23:0] tod_latch;
-reg  [23:0] tod_count;
-reg  [23:0] tod_alrm;
-wire [23:0] tod_nxt = tod_count + 1'd1;
-
-reg tod_rd; // reading from tod
-reg tod_wr; // writing to tod
-
-reg alrm_pls;
-
-wire sel_tod = sel_i & (adr_todlo | adr_todmi | adr_todhi);
-
-initial begin
-  // powerup state
-  tod_latch = 24'b0;
-  tod_count = 24'b0;
-  tod_alrm  = 24'b0;
-
-  tod_rd = 1'b0;
-  tod_wr = 1'b0;
-
-  alrm_pls = 1'b0;
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    tod_rd <= 1'b0;
-    tod_wr <= 1'b0;
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      crb_pbon <= 1'b0;
+      crb_otmd <= 1'b0;
+      crb_rnmd <= 1'b0;
+      crb_inmd <= 2'b0;
+      crb_alrm <= 1'b0;
+    end
+    else if (sel_crb & we_i)
+    begin
+      // handle write to crb (except for start and force load)
+      crb_pbon <= DBi[1];
+      crb_otmd <= DBi[2];
+      crb_rnmd <= DBi[3];
+      crb_inmd <= DBi[6:5];
+      crb_alrm <= DBi[7];
+    end
   end
-  else begin
-    if (~tod_rd)
-      tod_latch <= tod_count;
 
-    if (sel_i) begin
-      // handle tod latch/write
-      if (~we_i) begin
-        if (adr_todhi)
-          tod_rd <= 1'b1; // latch register when reading tod_hi
-        if (adr_todlo)
-          tod_rd <= 1'b0; // unlatch register when reading tod low
+  // TOD counter
+
+  wire [23:0] tod_latch; // tod_latch from tod helper
+  wire        alrm_pls;  // alrm pulse from tod helper
+  wire        tod_tck;   // tod count enable from tod helper
+
+  reg  [23:0] tod_count; // tod counter
+  reg  [23:0] tod_alrm;  // tod alrm
+  reg         tod_pls;
+
+  wire sel_tod = sel_i & (adr_todlo | adr_todmi | adr_todhi);
+
+  cia_tod tod(
+            .clk_i(ECLK),
+            .rst_i(rst_i),
+            .tod_i(TOD),
+            .sel_i(sel_tod),
+            .we_i(we_i),
+            .sel_alrm_i(crb_alrm),
+            .sel_todlo_i(adr_todlo),
+            .sel_todmi_i(adr_todmi),
+            .sel_todhi_i(adr_todhi),
+            .alrm_i(tod_alrm),
+            .count_i(tod_count),
+            .latch_o(tod_latch),
+            .cnt_o(tod_tck),
+            .cnt_i(tod_pls),
+            .pls_o(alrm_pls)
+          );
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      tod_count <= 24'b0;
+      tod_pls <= 1'b0;
+    end
+    else if (sel_tod & we_i & ~crb_alrm)
+    begin
+      tod_pls <= 1'b0;
+
+      if (adr_todlo)
+        tod_count[7:0] <= DBi;
+      if (adr_todmi)
+        tod_count[15:8] <= DBi;
+      if (adr_todhi)
+        tod_count[23:16] <= DBi;
+    end
+    else
+    begin
+      tod_pls <= tod_tck;
+      tod_count <= tod_count + tod_tck;
+    end
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      tod_alrm <= 24'b0;
+    end
+    else if (sel_tod & we_i & crb_alrm)
+    begin
+      if (adr_todlo)
+        tod_alrm[7:0] <= DBi;
+      if (adr_todmi)
+        tod_alrm[15:8] <= DBi;
+      if (adr_todhi)
+        tod_alrm[23:16] <= DBi;
+    end
+  end
+
+
+  // Timer A
+
+  reg  [15:0] ta_latch;
+  wire [15:0] ta_count;
+  reg  ta_fld; // force load
+  wire ta_run; // timer run flag (stable for read)
+
+  // timer underflow strobes
+  wire ta_ufl; // underflow flag useable on phi2 posedge
+  wire ta_pls; // underflow pulse useable on phi2 negedge
+
+  // timer input/output (for PRB)
+  wire ta_i = cra_inmd ? cnt_pls : 1'b1;
+  wire ta_o;
+
+  cia_timer ta(
+              .clk_i(ECLK),
+              .rst_i(rst_i),
+              .cnt_i(ta_i),
+              .omd_i(cra_otmd),
+              .str_i(cra_strt),
+              .fld_i(ta_fld),
+              .fste_i(fste_r),
+              .frle_i(frle_r),
+              .lch_i(ta_latch),
+              .cnt_o(ta_count),
+              .run_o(ta_run),
+              .pls_o(ta_pls),
+              .prb_o(ta_o),
+              .unfl_o(ta_ufl)
+            );
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      ta_latch <= 16'hffff;
+    end
+    else if (sel_i & we_i)
+    begin
+      if (adr_talo)
+        ta_latch[7:0]  <= DBi;
+      if (adr_tahi)
+        ta_latch[15:8] <= DBi;
+    end
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      cra_strt <= 1'b0;
+    end
+    else if (sel_cra & we_i) // write to cra bit 1
+      cra_strt <= DBi[0];
+    else if (sel_i & adr_tahi & we_i & cra_rnmd & ~cra_strt) // write to TAHI when in oneshot mode and not already running
+      cra_strt <= 1'b1;
+    else if (ta_pls & cra_rnmd) // oneshot timer expired
+      cra_strt <= 1'b0;
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      ta_fld <= 1'b0;
+    end
+    else if (sel_cra & we_i) // write to cra bit 4 (force load strobe)
+      ta_fld <= DBi[4];
+    else // timer is reloaded when TAHI is written and counter not running
+      ta_fld <= sel_i & adr_tahi & we_i & ~cra_strt;
+  end
+
+  // Timer B
+
+  reg  [15:0] tb_latch;
+  wire [15:0] tb_count;
+  reg  tb_fld; // force load
+  wire tb_run; // timer run flag (stable for read)
+
+  // timer underflow strobes
+  wire tb_ufl; // underflow flag useable on phi2 posedge
+  wire tb_pls; // underflow pulse useable on phi2 negedge
+
+  // timer input/output
+  reg  tb_i;
+  wire tb_o;
+
+  always @(*)
+  begin
+    case(crb_inmd)
+      default: // phi2 positive transitions
+        tb_i = 1'b1;
+      2'b01: // cnt rising edges
+        tb_i = cnt_pls;
+      2'b10: // timer A underflow
+        tb_i = ta_ufl;
+      2'b11: // timer A underflow while cnt is high
+        tb_i = ta_ufl & cnt_s[2];
+    endcase
+  end
+
+  cia_timer tb(
+              .clk_i(ECLK),
+              .rst_i(rst_i),
+              .cnt_i(tb_i),
+              .omd_i(crb_otmd),
+              .str_i(crb_strt),
+              .fld_i(tb_fld),
+              .fste_i(fste_r),
+              .frle_i(frle_r),
+              .lch_i(tb_latch),
+              .cnt_o(tb_count),
+              .run_o(tb_run),
+              .pls_o(tb_pls),
+              .prb_o(tb_o),
+              .unfl_o(tb_ufl)
+            );
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      tb_latch <= 16'hffff;
+    end
+    else if (sel_i & we_i)
+    begin
+      if (adr_tblo)
+        tb_latch[7:0]  <= DBi;
+      if (adr_tbhi)
+        tb_latch[15:8] <= DBi;
+    end
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      crb_strt <= 1'b0;
+    end
+    else if (sel_crb & we_i) // write to crb bit 1
+      crb_strt <= DBi[0];
+    else if (sel_i & adr_tbhi & we_i & crb_rnmd & ~crb_strt) // write to TBHI when in oneshot mode and not already running
+      crb_strt <= 1'b1;
+    else if (tb_pls & crb_rnmd) // oneshot timer expired
+      crb_strt <= 1'b0;
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      tb_fld <= 1'b0;
+    end
+    else if (sel_crb & we_i) // write to crb bit 4 (force load strobe)
+      tb_fld <= DBi[4];
+    else // timer is reloaded when TBHI is written and counter not running
+      tb_fld <= sel_i & adr_tbhi & we_i & ~crb_strt;
+  end
+
+  // serial port
+
+  reg  [7:0] sdr_r; // actual data in sdr register
+  wire [7:0] sdr_w; // incoming data from module
+  wire spi_pls; // serial input pulse
+  wire spo_pls; // serial output pulse
+
+  reg  spoe_o;
+  wire spoe_i;
+
+  cia_serial serial(
+               .clk_i(ECLK),
+               .rst_i(rst_i),
+               .dat_i(sdr_r),
+               .dat_o(sdr_w),
+               .unfl_i(ta_ufl),
+               .cnt_i(cnt_pls),
+               .cnt_o(CNTo),
+               .sp_i(spi_s[2]),
+               .sp_o(SPo),
+               .spmd_i(cra_spmd),
+               .spoe_i(spoe_o),
+               .spoe_o(spoe_i),
+               .spo_o(spo_pls),
+               .spi_o(spi_pls)
+             );
+
+  // handle writes to sdr
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      sdr_r  <= 8'd0;
+      spoe_o <= 1'd0;
+    end
+    else if (sel_i & we_i & adr_sdr)
+    begin
+      // handle bus write to sdr register
+      sdr_r <= DBi;
+      spoe_o <= ~spoe_i;
+    end
+    else if (spi_pls)
+    begin
+      // handle incoming serial data
+      sdr_r <= sdr_w;
+    end
+  end
+
+  // handshake stuff
+
+  wire flag_pls;
+
+  cia_handshake handshake(
+                  .clk_i(ECLK),
+                  .prb_i(sel_i & adr_prb),
+                  .flg_ni(nFLAG),
+                  .pls_o(flag_pls),
+                  .pc_no(nPC)
+                );
+
+  // Port A/B.
+  reg [7:0] pra;
+  reg [7:0] prb;
+
+  reg [7:0] ddra;
+  reg [7:0] ddrb;
+
+  assign PRAd = ddra;
+  assign PRBd = { crb_pbon | ddrb[7], cra_pbon | ddrb[6], ddrb[5:0] };
+
+  assign PRAo = pra & PRAd;
+  assign PRBo = { crb_pbon ? tb_o : prb[7], cra_pbon ? ta_o : prb[6], prb[5:0] } & PRBd;
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      pra  <= 8'd0;
+      prb  <= 8'd0;
+      ddra <= 8'd0;
+      ddrb <= 8'd0;
+    end
+    else if (sel_i & we_i)
+    begin
+      if (adr_pra)
+        pra   <= DBi;
+      if (adr_prb)
+        prb   <= DBi;
+      if (adr_ddra)
+        ddra  <= DBi;
+      if (adr_ddrb)
+        ddrb  <= DBi;
+    end
+  end
+
+  // clock domain crossing for port A/B inputs
+  reg [7:0] pra_s;
+  reg [7:0] prb_s;
+
+  reg [7:0] pra_r;
+  reg [7:0] prb_r;
+
+  always @(posedge ECLK)
+  begin
+    pra_s <= PRAi;
+    prb_s <= PRBi;
+  end
+
+  always @(posedge ECLK)
+  begin
+    pra_r <= pra_s;
+    prb_r <= prb_s;
+  end
+
+  // Interrupt handling.
+  reg [4:0] icr_m; // interrupts mask
+  reg       icr_rst; // interrupts reset following read
+  reg       irq_d; // interrupts delay (if active)
+
+  wire [4:0] icr_o;
+  wire       ir;
+
+  cia_irq irqs(
+            .clk_i(ECLK),
+            .rst_i(rst_i),
+            .ta_i(ta_ufl),
+            .tb_i(tb_ufl),
+            .alrm_i(alrm_pls),
+            .sp_i(spo_pls | spi_pls),
+            .flg_i(flag_pls),
+            .msk_i(icr_m),
+            .clr_i(icr_rst),
+            .icr_o(icr_o),
+            .irq_o(ir)
+          );
+
+  assign nIRQ = irq_d;
+
+  always @(negedge ECLK)
+  begin
+    irq_d <= ~ir;
+  end
+
+  always @(negedge ECLK)
+  begin
+    if (rst_i)
+    begin
+      icr_m <= 5'b0;
+      icr_rst <= 1'b0;
+    end
+    else if (sel_i & adr_icr)
+    begin
+      icr_rst <= ~we_i;
+
+      if (we_i)
+      begin
+        if (DBi[7])
+          icr_m <= icr_m |  DBi[4:0];
+        else
+          icr_m <= icr_m & ~DBi[4:0];
       end
-      else if (~crb_alrm) begin
-        if (adr_todhi | adr_todmi)
-          tod_wr <= 1'b1; // stop tod when writing tod_hi/tod_mi
-        if (adr_todlo)
-          tod_wr <= 1'b0; // restart tod when writing tod_lo
-      end
+    end
+    else
+    begin
+      icr_rst <= 1'b0;
     end
   end
-end
 
-// tick the tod
-wire tod_tck = tod_pls & ~tod_wr;
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    tod_count <= 24'b0;
-  end
-  else if (sel_tod & we_i & ~crb_alrm) begin
-    if (adr_todlo)
-      tod_count[7:0] <= DBi;
-    if (adr_todmi)
-      tod_count[15:8] <= DBi;
-    if (adr_todhi)
-      tod_count[23:16] <= DBi;
-  end
-  else if (tod_tck) begin
-    // increment tod count
-    tod_count <= tod_nxt;
-  end
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    alrm_pls <= 1'b0;
-  end
-  else if (tod_tck)
-    // check for alrm if tod running
-    alrm_pls <= tod_alrm == tod_nxt;
-  else
-    alrm_pls <= 1'b0;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    tod_alrm <= 24'b0;
-  end
-  else if (sel_tod & we_i & crb_alrm) begin
-    if (adr_todlo)
-      tod_alrm[7:0] <= DBi;
-    if (adr_todmi)
-      tod_alrm[15:8] <= DBi;
-    if (adr_todhi)
-      tod_alrm[23:16] <= DBi;
-  end
-end
-
-// Timer A
-
-reg [15:0] ta_latch;
-reg [15:0] ta_count;
-reg ta_tgl; // timer toggle output
-reg ta_run; // timer run flag (stable for read)
-reg ta_tck; // timer tick flag
-reg ta_fld; // force load
-
-// since latch and count are inverted we use addition and carry instead of substraction and borrow
-wire [16:0] ta_nxt = ta_count + 1'd1;
-wire ta_z = ta_nxt[16]; // use carry to detect zero
-
-// timer fast and expiration flags
-wire ta_fst = ~cra_inmd & ~cra_rnmd & ta_z & (&ta_latch);
-reg  ta_exp; // timer expiration flag (may be continuous)
-
-// timer output pulse (on PB6)
-wire ta_pls = ta_fst ? ta_exp & ~ECLK : ta_exp;
-
-// timer input/output
-wire ta_i = cra_inmd ? cnt_pls : 1'b1;
-wire ta_o = cra_otmd ? ta_tgl : ta_pls;
-
-initial begin
-  // powerup state
-  ta_latch = 16'h0000;
-  ta_count = 16'h0000;
-  ta_tgl = 1'b0;
-  ta_run = 1'b0;
-  ta_tck = 1'b0;
-  ta_fld = 1'b0;
-  ta_exp = 1'b0;
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    ta_run <= 1'b0;
-    ta_tck <= 1'b0;
-    ta_count <= 16'h0000;
-  end
-  else begin
-    ta_run <= cra_strt;
-    ta_tck <= cra_strt & ta_i;
-
-    if (cra_strt & ta_i) begin
-      ta_count <= ta_fld | ta_z ? ta_latch : ta_nxt[15:0];
-    end
-    else if (ta_fld) begin
-      ta_count <= ta_latch;
-    end
-  end
-end
-
-// timer underflow flag (valid on negedge only)
-wire ta_unfl = ta_z & ta_tck;
-
-always @(negedge ECLK) begin
-  // trigger timer expiration on underflow
-  ta_exp <= ta_unfl;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    // toggle output is set low by reset
-    ta_tgl <= 1'b0;
-  end
-  else if (sel_cra & we_i & DBi[0] & ~cra_strt) begin
-    // toggle output is set high whenever the timer is started
-    ta_tgl <= 1'b1;
-  end
-  else if (ta_unfl) begin
-    // switch toggle output on underflow
-    ta_tgl <= ~ta_tgl;
-  end
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    ta_latch <= 16'h0000;
-  end
-  else if (sel_i & we_i) begin
-    if (adr_talo)
-      ta_latch[7:0]  <= ~DBi;
-    if (adr_tahi)
-      ta_latch[15:8] <= ~DBi;
-  end
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    cra_strt <= 1'b0;
-  end
-  else if (sel_cra & we_i) // write to cra bit 1
-    cra_strt <= DBi[0];
-  else if (sel_i & adr_tahi & we_i & cra_rnmd & ~cra_strt) // write to TAHI when not running in oneshot mode
-    cra_strt <= 1'b1;
-  else if (ta_z & cra_rnmd) // oneshot timer expired
-    cra_strt <= 1'b0;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    ta_fld <= 1'b0;
-  end
-  else if (sel_cra & we_i) // write to cra bit 4 (force load strobe)
-    ta_fld <= DBi[4];
-  else // timer is reloaded when it has expired or when TAHI is written and counter not running
-    ta_fld <= ta_z | (sel_i & adr_tahi & we_i & ~cra_strt);
-end
-
-// Timer B
-
-reg [15:0] tb_latch;
-reg [15:0] tb_count;
-reg tb_tgl; // timer toggle output
-reg tb_run; // timer run flag (stable for read)
-reg tb_tck; // timer tick flag
-reg tb_fld; // force load
-
-// since latch and count are inverted we use addition and carry instead of substraction and borrow
-wire [16:0] tb_nxt = tb_count + 1'd1;
-wire tb_z = tb_nxt[16]; // use carry to detect zero
-
-// timer fast and expiration flags
-wire tb_fst = (crb_inmd == 2'b00) & ~crb_rnmd & tb_z & (&tb_latch);
-reg  tb_exp; // timer expiration flag (may be continuous)
-
-// timer output pulse (on PB7)
-wire tb_pls = tb_fst ? tb_exp & ~ECLK : tb_exp;
-
-// timer input/output
-reg  tb_i;
-wire tb_o = crb_otmd ? tb_tgl : tb_pls;
-
-always @(*) begin
-  case(crb_inmd)
-    default: // phi2 positive transitions
-      tb_i = 1'b1;
-    2'b01: // cnt rising edges
-      tb_i = cnt_pls;
-    2'b10: // timer A underflow
-      tb_i = ta_exp;
-    2'b11: // timer A underflow while cnt is high
-      tb_i = ta_exp & cnt_s[1];
-  endcase
-end
-
-initial begin
-  // powerup state
-  tb_latch = 16'h0000;
-  tb_count = 16'h0000;
-  tb_tgl = 1'b0;
-  tb_run = 1'b0;
-  tb_tck = 1'b0;
-  tb_fld = 1'b0;
-  tb_exp = 1'b0;
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    tb_run <= 1'b0;
-    tb_tck <= 1'b0;
-    tb_count <= 16'h0000;
-  end
-  else begin
-    tb_run <= crb_strt;
-    tb_tck <= crb_strt & tb_i;
-
-    if (crb_strt & tb_i) begin
-      tb_count <= tb_fld | tb_z ? tb_latch : tb_nxt[15:0];
-    end
-    else if (tb_fld) begin
-      tb_count <= tb_latch;
-    end
-  end
-end
-
-// timer underflow flag (valid on negedge only)
-wire tb_unfl = tb_z & tb_tck;
-
-always @(negedge ECLK) begin
-  // trigger timer expiration on underflow
-  tb_exp <= tb_unfl;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    // toggle output is set low by reset
-    tb_tgl <= 1'b0;
-  end
-  else if (sel_crb & we_i & DBi[0] & ~crb_strt) begin
-    // toggle output is set high whenever the timer is started
-    tb_tgl <= 1'b1;
-  end
-  else if (tb_unfl) begin
-    // switch toggle output on underflow
-    tb_tgl <= ~tb_tgl;
-  end
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    tb_latch <= 16'h0000;
-  end
-  else if (sel_i & we_i) begin
-    if (adr_tblo)
-      tb_latch[7:0]  <= ~DBi;
-    if (adr_tbhi)
-      tb_latch[15:8] <= ~DBi;
-  end
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    crb_strt <= 1'b0;
-  end
-  else if (sel_crb & we_i) // write to crb bit 1
-    crb_strt <= DBi[0];
-  else if (sel_i & adr_tbhi & we_i & crb_rnmd & ~crb_strt) // write to TBHI when not running in oneshot mode
-    crb_strt <= 1'b1;
-  else if (tb_z & crb_rnmd) // oneshot timer expired
-    crb_strt <= 1'b0;
-end
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    tb_fld <= 1'b0;
-  end
-  else if (sel_crb & we_i) // write to crb bit 4 (force load strobe)
-    tb_fld <= DBi[4];
-  else // timer is reloaded when it has expired or when TBHI is written and counter not running
-    tb_fld <= tb_z | (sel_i & adr_tbhi & we_i & ~crb_strt);
-end
-
-// serial port input
-
-reg [7:0] spi_dat; // serial input data register
-reg [8:0] spi_shf; // serial shift register for input
-reg [2:0] spi_cnt; // serial input shift count
-
-wire [3:0] spi_nxt = { 1'b0, spi_cnt } + 1'd1;
-reg        spi_rdy; // full byte is ready
-
-always @(posedge ECLK) begin
-  // sample serial input with CNTi (available at next clock edge)
-  spi_shf[0] <= SPi;
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    spi_shf[8:1] <= 8'b0;
-    spi_cnt <= 3'b0;
-    spi_rdy <= 1'b0;
-  end
-  else if (~cra_spmd & cnt_pls) begin
-    // shift data in
-    spi_shf[8:1] <= spi_shf[7:0];
-    spi_cnt <= spi_nxt[2:0];
-    spi_rdy <= spi_nxt[3]; // use carry as ready flag
-  end
-  else if (spi_rdy) begin
-    // keep ready flag on one clock cycle
-    spi_rdy <= 1'b0;
-  end
-end
-
-reg spi_pls;
-
-always @(negedge ECLK) begin
-  // detect end of transmission
-  spi_pls <= spi_rdy;
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    spi_dat <= 8'b0;
-  end
-  else if (spi_rdy) begin
-    spi_dat <= spi_shf[8:1];
-  end
-end
-
-initial begin
-  // powerup state
-  spi_dat = 8'b0;
-  spi_shf = 9'b0;
-  spi_cnt = 3'b0;
-  spi_rdy = 1'b0;
-  spi_pls = 1'b0;
-end
-
-// serial port output
-
-reg [7:0] spo_dat; // serial data register for output
-reg       spo_pnd; // pending data in spo_dat
-reg       spo_clr; // clear flag for spo_dat (set on negedge)
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    spo_pnd <= 1'b0;
-    spo_dat <= 8'b0;
-  end
-  else if (adr_sdr & sel_i & we_i) begin // write to sdr register, mark data as pending
-    spo_dat <= DBi;
-    spo_pnd <= 1'b1;
-  end
-  else
-    spo_pnd <= spo_pnd & ~spo_clr;
-end
-
-reg [7:0] spo_shf; // serial shift register for output
-reg [3:0] spo_cnt; // shift count and cnt output clock (LSB)
-reg       spo_bsy; // data shifting out
-
-// next shift count, MSB is next value for spo_bsy
-wire [4:0] spo_nxt = { 1'b0, spo_cnt } + 1'd1;
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    spo_bsy <= 1'b0;
-    spo_shf <= 8'b0;
-    spo_cnt <= 4'b0000;
-  end
-  else if (cra_spmd & ta_exp) begin
-    if (spo_bsy) begin
-      if (~spo_nxt[4] & spo_nxt[0])
-        spo_shf <= { spo_shf[6:0], 1'b0 };
-
-      spo_bsy <= ~spo_nxt[4];
-      spo_cnt <= spo_nxt[3:0];
-    end
-    else if (spo_pnd) begin
-      spo_shf <= spo_dat;
-      spo_bsy <= spo_pnd;
-      spo_cnt <= spo_nxt[3:0];
-    end
-  end
-end
-
-reg spo_pls;
-
-always @(negedge ECLK) begin
-  SPo <= spo_shf[7];
-  CNTo <= spo_bsy ? ~spo_cnt[0] : 1'b1;
-  spo_pls <= cra_spmd & ta_unfl & spo_nxt[4];
-end
-
-always @(posedge ECLK) begin
-  spo_clr <= cra_spmd & spo_pnd & ta_exp & ~spo_bsy;
-end
-
-initial begin
-  // powerup state
-  spo_dat = 8'b0;
-  spo_shf = 8'b0;
-  spo_cnt = 4'b0;
-  spo_bsy = 1'b0;
-  spo_pnd = 1'b0;
-  spo_clr = 1'b0;
-  spo_pls = 1'b0;
-end
-
-// handshake stuff
-
-reg [2:0] flag_s;
-
-wire flag_pls = ~flag_s[2] & flag_s[1];
-
-always @(negedge ECLK) begin
-  // trigger PC low for 1 clock cycle following a read or write to PRB
-  nPC <= ~(sel_i & adr_prb);
-end
-
-always @(posedge ECLK) begin
-  // start flag signal sync
-  flag_s[0] <= ~nFLAG;
-end
-
-always @(negedge ECLK) begin
-  // end flag signal sync and trigger pulse for 1 clock cycle
-  { flag_s[2], flag_s[1] } <= { flag_s[1], flag_s[0] };
-end
-
-initial begin
-  // powerup state
-  flag_s = 3'b0;
-  nPC = 1'b1;
-end
-
-// Port A/B.
-reg [7:0] pra;
-reg [7:0] prb;
-
-reg [7:0] ddra;
-reg [7:0] ddrb;
-
-initial begin
-  // powerup state
-  pra = 8'b0;
-  prb = 8'b0;
-  ddra = 8'b0;
-  ddrb = 8'b0;
-end
-
-assign PRAd = ddra;
-assign PRBd = { crb_pbon ? 1'b1 : ddrb[7], cra_pbon ? 1'b1 : ddrb[6], ddrb[5:0] };
-
-assign PRAo = pra & PRAd;
-assign PRBo = { crb_pbon ? tb_o : prb[7], cra_pbon ? ta_o : prb[6], prb[5:0] } & PRBd;
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    pra  <= 8'd0;
-    prb  <= 8'd0;
-    ddra <= 8'd0;
-    ddrb <= 8'd0;
-  end
-  else if (sel_i & we_i) begin
-    if (adr_pra)
-      pra   <= DBi;
-    if (adr_prb)
-      prb   <= DBi;
-    if (adr_ddra)
-      ddra  <= DBi;
-    if (adr_ddrb)
-      ddrb  <= DBi;
-  end
-end
-
-// clock domain crossing for port A/B inputs
-reg [7:0] pra_s;
-reg [7:0] prb_s;
-
-reg [7:0] pra_r;
-reg [7:0] prb_r;
-
-always @(posedge ECLK) begin
-  pra_s <= PRAi;
-  prb_s <= PRBi;
-end
-
-always @(posedge ECLK) begin
-  pra_r <= pra_s;
-  prb_r <= prb_s;
-end
-
-// Interrupt handling.
-reg [4:0] icr_m; // interrupts mask
-
-reg icr_rst; // interrupts reset following read
-reg icr_flg;
-reg icr_sp;
-reg icr_alrm;
-reg icr_tb;
-reg icr_ta;
-
-initial begin
-  // powerup state
-  icr_m = 5'b0;
-  icr_rst = 1'b0;
-  icr_flg = 1'b0;
-  icr_sp = 1'b0;
-  icr_alrm = 1'b0;
-  icr_tb = 1'b0;
-  icr_ta = 1'b0;
-end
-
-wire [4:0] icr_d = { icr_flg, icr_sp, icr_alrm, icr_tb, icr_ta };
-wire [4:0] icr_o = icr_m & icr_d;
-wire       ir    = |(icr_o);
-
-assign nIRQ = ~ir;
-
-always @(negedge ECLK) begin
-  if (rst_i) begin
-    icr_m <= 5'b0;
-    icr_rst <= 1'b0;
-  end
-  else if (sel_i & adr_icr) begin
-    icr_rst <= ~we_i;
-
-    if (we_i) begin
-      if (DBi[7])
-        icr_m <= icr_m |  DBi[4:0];
-      else
-        icr_m <= icr_m & ~DBi[4:0];
-    end
-  end
-  else begin
-    icr_rst <= 1'b0;
-  end
-end
-
-always @(posedge ECLK) begin
-  if (rst_i) begin
-    icr_flg  <= 1'b0;
-    icr_sp   <= 1'b0;
-    icr_alrm <= 1'b0;
-    icr_tb   <= 1'b0;
-    icr_ta   <= 1'b0;
-  end
-  else if (icr_rst) begin
-    icr_flg <= flag_pls;
-    icr_sp <= spo_pls | spi_pls;
-    icr_alrm <= alrm_pls;
-    icr_tb <= tb_exp;
-    icr_ta <= ta_exp;
-  end
-  else begin
-    icr_flg <= icr_flg | flag_pls;
-    icr_sp <= icr_sp | spo_pls | spi_pls;
-    icr_alrm <= icr_alrm| alrm_pls;
-    icr_tb <= icr_tb | tb_exp;
-    icr_ta <= icr_ta | ta_exp;
-  end
-end
-
-reg [7:0] dat_r;
-
-assign DBo = sel_i & ~we_i ? dat_r : 8'b0;
-
-always @(*) begin
-  case (RS)
-    REG_PRA:
-      dat_r = (pra_r & ~PRAd) | PRAo;
-    REG_PRB:
-      dat_r = (prb_r & ~PRBd) | PRBo;
-    REG_DDRA:
-      dat_r = ddra;
-    REG_DDRB:
-      dat_r = ddrb;
-    REG_TA_LO:
-      dat_r = ~ta_count[7:0];
-    REG_TA_HI:
-      dat_r = ~ta_count[15:8];
-    REG_TB_LO:
-      dat_r = ~tb_count[7:0];
-    REG_TB_HI:
-      dat_r = ~tb_count[15:8];
-    REG_TOD_LOW:
-      dat_r = tod_latch[7:0];
-    REG_TOD_MID:
-      dat_r = tod_latch[15:8];
-    REG_TOD_HI:
-      dat_r = tod_latch[23:16];
-    REG_SDR:
-      dat_r = spi_dat;
-    REG_ICR:
-      dat_r = { ir, 2'b00, icr_d[4:0] };
-    REG_CRA:
-      dat_r = {     1'b0, cra_spmd, cra_inmd, 1'b0, cra_rnmd, cra_otmd, cra_pbon, ta_run };
-    REG_CRB:
-      dat_r = { crb_alrm,           crb_inmd, 1'b0, crb_rnmd, crb_otmd, crb_pbon, tb_run };
-    default:
-      dat_r = 8'd0;
-  endcase
-end
+  wire [7:0] dat_w;
+
+  cia_decoder decoder(
+                .adr_i(RS),
+                .pra_i((pra_r & ~PRAd) | PRAo),
+                .prb_i((prb_r & ~PRBd) | PRBo),
+                .ddra_i(ddra),
+                .ddrb_i(ddrb),
+                .talo_i(ta_count[7:0]),
+                .tahi_i(ta_count[15:8]),
+                .tblo_i(tb_count[7:0]),
+                .tbhi_i(tb_count[15:8]),
+                .todlo_i(tod_latch[7:0]),
+                .todmid_i(tod_latch[15:8]),
+                .todhi_i(tod_latch[23:16]),
+                .ext_i({ 5'b0, frle_r, fste_r, fcnt_r }),
+                .sdr_i(sdr_r),
+                .icr_i({ ir, 2'b00, icr_o[4:0] }),
+                .cra_i({     1'b0, cra_spmd, cra_inmd, 1'b0, cra_rnmd, cra_otmd, cra_pbon, ta_run }),
+                .crb_i({ crb_alrm,           crb_inmd, 1'b0, crb_rnmd, crb_otmd, crb_pbon, tb_run }),
+                .dat_o(dat_w),
+                .pra_o(adr_pra),
+                .prb_o(adr_prb),
+                .ddra_o(adr_ddra),
+                .ddrb_o(adr_ddrb),
+                .talo_o(adr_talo),
+                .tahi_o(adr_tahi),
+                .tblo_o(adr_tblo),
+                .tbhi_o(adr_tbhi),
+                .todlo_o(adr_todlo),
+                .todmid_o(adr_todmi),
+                .todhi_o(adr_todhi),
+                .ext_o(adr_ext),
+                .sdr_o(adr_sdr),
+                .icr_o(adr_icr),
+                .cra_o(adr_cra),
+                .crb_o(adr_crb)
+              );
+
+  assign DBo = sel_i & ~we_i ? dat_w : 8'b0;
 endmodule

--- a/cia/cia8520_tb.v
+++ b/cia/cia8520_tb.v
@@ -1,10 +1,6 @@
-`timescale 10ns/10ns
+`timescale 1ns/1ns
 
-module cia_internal_tb;
-  // clock signals
-  reg rst;
-  reg clk;
-
+module cia_top_tb;
   localparam [4:0] CIAA_PRA = 5'h00;
   localparam [4:0] CIAA_PRB = 5'h01;
   localparam [4:0] CIAA_DDRA = 5'h02;
@@ -16,6 +12,7 @@ module cia_internal_tb;
   localparam [4:0] CIAA_TOD_LOW = 5'h08;
   localparam [4:0] CIAA_TOD_MID = 5'h09;
   localparam [4:0] CIAA_TOD_HI = 5'h0a;
+  localparam [4:0] CIAA_EXT = 5'h0b;
   localparam [4:0] CIAA_SDR = 5'h0c;
   localparam [4:0] CIAA_ICR = 5'h0d;
   localparam [4:0] CIAA_CRA = 5'h0e;
@@ -32,13 +29,21 @@ module cia_internal_tb;
   localparam [4:0] CIAB_TOD_LOW = 5'h18;
   localparam [4:0] CIAB_TOD_MID = 5'h19;
   localparam [4:0] CIAB_TOD_HI = 5'h1a;
+  localparam [4:0] CIAB_EXT = 5'h1b;
   localparam [4:0] CIAB_SDR = 5'h1c;
   localparam [4:0] CIAB_ICR = 5'h1d;
   localparam [4:0] CIAB_CRA = 5'h1e;
   localparam [4:0] CIAB_CRB = 5'h1f;
 
+  // Clock and reset
+  reg [1:0] clk_s;
+  wire c2m = clk_s[0];
+  reg c1m;
+  reg rst_i;
+
   // cia A specific signals
   reg  ciaa_sel;
+  wire ciaa_flag;
   wire ciaa_nirq_o;
 
   // cia B specific signals
@@ -46,10 +51,11 @@ module cia_internal_tb;
   wire ciab_flag;
   wire ciab_nirq_o;
 
-  reg tod_e;
+  reg tod_ovr;
+  reg tod_drv;
 
-  // will use timer B as tod source
-  wire tod_i = tod_e ? cia_prb[7] : 1'b0;
+  // enable tod pin
+  wire tod_i = tod_ovr ? tod_drv : 1'b0;
 
   // cia A/B common signals
   reg        cia_we;
@@ -62,7 +68,6 @@ module cia_internal_tb;
   // used to connect both CIAs
   wire [7:0] cia_pra;
   wire [7:0] cia_prb;
-  wire       cia_flag;
   wire       cia_cnt;
   wire       cia_sp;
 
@@ -72,15 +77,15 @@ module cia_internal_tb;
   assign cia_cnt = cnt_ovr ? cia_prb[6] : 1'bz;
 
   cia ciaa(
-        .ECLK(clk),
-        .nRES(~rst),
+        .ECLK(c1m),
+        .nRES(~rst_i),
         .nCS(~ciaa_sel),
         .RW(~cia_we),
         .RS(cia_adr),
         .DB(cia_dat),
         .PA(cia_pra),
         .PB(cia_prb),
-        .nFLAG(cia_flag),
+        .nFLAG(ciaa_flag),
         .SP(cia_sp),
         .CNT(cia_cnt),
         .TOD(tod_i),
@@ -90,8 +95,8 @@ module cia_internal_tb;
   pullup(ciab_flag);
 
   cia ciab(
-        .ECLK(clk),
-        .nRES(~rst),
+        .ECLK(c1m),
+        .nRES(~rst_i),
         .nCS(~ciab_sel),
         .RW(~cia_we),
         .RS(cia_adr),
@@ -99,14 +104,15 @@ module cia_internal_tb;
         .PA(cia_pra),
         .PB(cia_prb),
         .nFLAG(ciab_flag),
-        .nPC(cia_flag),
+        .nPC(ciaa_flag),
         .SP(cia_sp),
         .CNT(cia_cnt),
         .TOD(tod_i),
         .nIRQ(ciab_nirq_o)
       );
 
-  initial begin
+  initial
+  begin
     cia_we = 0;
     cia_adr = 0;
     cia_dat_i = 8'bx;
@@ -114,81 +120,273 @@ module cia_internal_tb;
     ciaa_sel = 0;
     ciab_sel = 0;
     cnt_ovr = 0;
-    tod_e = 0;
+    tod_ovr = 0;
   end
 
-  initial begin
-    @(negedge clk);
+  // Test sequence
+  initial
+  begin
+    $dumpfile("cia_top_tb.vcd");
+    $dumpvars(0, cia_top_tb);
+
+    repeat(4) @(posedge c2m); // small delay before starting tests
+
+    pulse_reset();
+
+    repeat(3) @(posedge c1m);
+
     cia_test_rst();
     cia_test_pra();
     cia_test_prb();
+    cia_test_serial_a_to_b(8'b01010101, 0);
+    cia_test_serial_a_to_b(8'b01010101, 1);
+    cia_test_serial_b_to_a(8'b00000000, 0);
+    cia_test_serial_b_to_a(8'b11111111, 1);
     cia_test_timera();
-    @(posedge clk) $finish;
+    cia_test_tod();
+    $finish;
   end
 
   task cia_test_timera();
     begin
+      // disable all extensions (vanilla CIA)
+      cia_write_cycle(CIAA_EXT, 8'b00000000); // set CIA A extensions
+      cia_write_cycle(CIAB_EXT, 8'b00000000); // set CIA B extensions
+
+      // clear interrupts
+      cia_read_cycle(CIAA_ICR);
+      cia_read_cycle(CIAB_ICR);
+
       cia_write_cycle(CIAA_DDRB, 8'b00000000);
       cia_write_cycle(CIAB_DDRB, 8'b00111111);
       cia_write_cycle(CIAA_CRA, 8'b00001010); // sets oneshot, PB6ON, pulse
       cia_write_cycle(CIAA_CRB, 8'b00000010); // sets PB6ON
       cia_write_cycle(CIAA_PRB, 8'b00000000);
       cia_write_cycle(CIAB_PRB, 8'b00000000);
-      @(posedge clk); // signal generated at port B
-      @(posedge clk); // first stage port B sync
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_read_check(CIAA_PRB, 8'b00000000);
-      cia_write_cycle(CIAA_TA_LO, 8'b00000000);
-      cia_write_cycle(CIAA_TA_HI, 8'b00000000); // should start timer
-      @(negedge clk); // Timer underflow
-      @(posedge clk); // signal generated at port B
-      @(posedge clk); // first stage port B sync
-      cia_read_check(CIAB_PRB, 8'b01000000); // check output pulse from timer A (high)
-      cia_read_check(CIAB_PRB, 8'b00000000); // check output pulse from timer A (low)
-      cia_write_cycle(CIAA_CRA, 8'b00000011); // sets PB6ON, pulse, and restart counter (fast mode)
-      @(negedge clk)
-      #25 if (~cia_prb[6]) $display("fast pulse error");
-      @(posedge clk)
-      #25 if ( cia_prb[6]) $display("fast pulse error");
-      @(negedge clk)
-      #25 if (~cia_prb[6]) $display("fast pulse error");
-      @(posedge clk)
-      #25 if ( cia_prb[6]) $display("fast pulse error");
-      cia_write_cycle(CIAA_CRA, 8'b00000111); // change to toggle output
-      @(negedge clk);
-      cia_read_check(CIAB_PRB, 8'b01000000); // check toggle output from timer A (high)
-      cia_read_check(CIAB_PRB, 8'b00000000); // check toggle output from timer A (low)
-      cia_read_check(CIAB_PRB, 8'b01000000); // check toggle output from timer A (high)
-      cia_read_check(CIAB_PRB, 8'b00000000); // check toggle output from timer A (low)
-      cia_read_check(CIAB_PRB, 8'b01000000); // check toggle output from timer A (high)
-      cia_read_check(CIAB_PRB, 8'b00000000); // check toggle output from timer A (low)
-      cia_write_cycle(CIAA_CRA, 8'b00001010); // stop timer, oneshot, PB6ON, pulse
-      cia_write_cycle(CIAA_TA_LO, 8'd4);
-      cia_write_cycle(CIAA_TA_HI, 8'b00000000); // should start timer
-      cia_read_check(CIAA_TA_LO, 8'd4); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd3); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd2); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd1); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd0); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd4); // check toggle output from timer A (low)
-      cia_write_cycle(CIAA_CRA, 8'b00000011); // start timer (continuous), PB6ON, pulse
-      cia_read_check(CIAA_TA_LO, 8'd3); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd2); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd1); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd0); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd4); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd3); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd2); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd1); // check toggle output from timer A (low)
-      cia_read_check(CIAA_TA_LO, 8'd0); // check toggle output from timer A (low)
-      @(posedge clk);
-      @(posedge clk);
-      @(posedge clk);
-      @(posedge clk);
+      cia_read_check(CIAB_PRB, 8'b00000000);
+
+      // Test 1 : Basic countdown from 5 to underflow with pulse output
+
+      cia_write_cycle(CIAA_TA_LO, 8'd5);
+      cia_write_cycle(CIAA_TA_HI, 8'b00000000); // force load and start timer
+
+      // first check timer only using external (cpu bus) interface
+      cia_read_check(CIAA_TA_LO, 8'd5); // suppressed tick (due to force load)
+      cia_read_check(CIAA_TA_LO, 8'd5);
+      cia_read_check(CIAA_TA_LO, 8'd4);
+      cia_read_check(CIAA_TA_LO, 8'd3);
+      cia_read_check(CIAA_TA_LO, 8'd2);
+      cia_read_check(CIAA_TA_LO, 8'd1);
+      cia_read_check(CIAA_TA_LO, 8'd0);
+      cia_read_check(CIAA_TA_LO, 8'd5);
+      cia_read_check(CIAA_ICR, 8'b00010001);
+
+      // ensure timer is not running anymore
+      cia_read_check(CIAA_TA_LO, 8'd5);
+      cia_read_check(CIAA_TA_LO, 8'd5);
+      cia_read_check(CIAA_TA_LO, 8'd5);
+
+      // recheck using internal signals
+      cia_write_cycle(CIAA_TA_HI, 8'b00000000); // force load and start timer (again)
+
+      // check internal signals (for precise timing)
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd5);
+      @(negedge c1m) check_counter(16'd5); // suppressed tick (due to force load)
+      @(negedge c1m) check_counter(16'd4);
+      @(negedge c1m) check_counter(16'd3);
+      @(negedge c1m) check_counter(16'd2);
+      @(negedge c1m) check_counter(16'd1);
+      @(negedge c1m) check_counter(16'd0);
+
+      @(posedge c1m); // switch edge to read outputs
+      check_underflow(1'b1); // counter will underflow on next tick
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      @(negedge c1m) check_counter(16'd5); // counter reload
+      @(posedge c1m);
+
+      check_underflow(1'b0); // ensure underflow is not asserted anymore
+      check_pulse(1'b1); // output pulse is now generated
+      check_port(1'b1);  // port output pulse has been generated also
+
+      @(negedge c1m) check_counter(16'd5); // counter stopped
+      @(posedge c1m);
+
+      // ensure nothing is remaining
+      check_underflow(1'b0);
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      // Test 1a : Basic countdown from 5 to underflow with pulse output
+      // This test uses latch from previous test
+
+      cia_write_cycle(CIAA_CRA, 8'b00000011); // start in continuous, pulse
+
+      // check internal signals (for precise timing)
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd5);
+      @(negedge c1m) check_counter(16'd4);
+      @(negedge c1m) check_counter(16'd3);
+      @(negedge c1m) check_counter(16'd2);
+      @(negedge c1m) check_counter(16'd1);
+      @(negedge c1m) check_counter(16'd0);
+
+      @(posedge c1m); // switch edge to read outputs
+      check_underflow(1'b1); // counter will underflow on next tick
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      @(negedge c1m) check_counter(16'd5); // counter reload
+      @(posedge c1m);
+
+      check_underflow(1'b0); // ensure underflow is not asserted anymore
+      check_pulse(1'b1); // output pulse is now generated
+      check_port(1'b1);  // port output pulse has been generated also
+
+      @(negedge c1m) check_counter(16'd5); // suppressed tick
+      @(posedge c1m);
+
+      // ensure nothing is remaining
+      check_underflow(1'b0);
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      @(negedge c1m) check_counter(16'd4);
+      @(negedge c1m) check_counter(16'd3);
+      @(negedge c1m) check_counter(16'd2);
+      @(negedge c1m) check_counter(16'd1);
+      @(negedge c1m) check_counter(16'd0);
+
+      @(posedge c1m); // switch edge to read outputs
+      check_underflow(1'b1); // counter will underflow on next tick
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      @(negedge c1m) check_counter(16'd5); // counter reload
+      @(posedge c1m);
+
+      check_underflow(1'b0); // ensure underflow is not asserted anymore
+      check_pulse(1'b1); // output pulse is now generated
+      check_port(1'b1);  // port output pulse has been generated also
+
+      @(negedge c1m) check_counter(16'd5); // suppressed tick
+      @(posedge c1m);
+
+      // ensure nothing is remaining
+      check_underflow(1'b0);
+      check_pulse(1'b0);
+      check_port(1'b0);
+
+      cia_write_cycle(CIAA_CRA, 8'b00000010); // stop timer
+
+      // Test 2 : Toggle mode
+
+      cia_write_cycle(CIAA_TA_LO, 8'd3); // load 3 in talo
+      cia_write_cycle(CIAA_TA_HI, 8'b00000000); // force load timer (because not running)
+
+      @(negedge ciaa.ciai.ta.fld_i) check_counter(16'd3);
+
+      cia_write_cycle(CIAA_CRA, 8'b00000111); // start in continuous, toggle on pb
+
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd3);
+      @(negedge c1m) check_port(1'b1); // toggle must be high after start
+
+      @(posedge ciaa.ciai.ta.pls_o); // await for registered underflow
+      @(posedge c1m) check_port(1'b0); // reload and check toggle output (low)
+
+      @(posedge ciaa.ciai.ta.pls_o); // await for registered underflow
+      @(posedge c1m) check_port(1'b1); // reload and check toggle output (high)
+
+      @(posedge ciaa.ciai.ta.pls_o); // await for registered underflow
+      @(posedge c1m) check_port(1'b0); // reload and check toggle output (low)
+
+      cia_write_cycle(CIAA_CRA, 8'b00000110); // stop timer
+
+      repeat(2) @(posedge c1m) check_port(1'b0); // check toggle output (low, must not change after stop)
+
+      // Test 2b: Toggle reset on restart
+
+      cia_write_cycle(CIAA_TA_LO, 8'd2); // load 2 in talo
+      cia_write_cycle(CIAA_CRA, 8'b00010111); // start timer with force load
+
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd2);
+      @(negedge c1m) check_port(1'b1); // toggle must be high after start
+
+      @(posedge ciaa.ciai.ta.pls_o); // await for registered underflow
+      @(posedge c1m) check_port(1'b0); // reload and check toggle output (low)
+
+      @(posedge ciaa.ciai.ta.pls_o); // await for registered underflow
+      @(posedge c1m) check_port(1'b1); // reload and check toggle output (high)
+
+      cia_write_cycle(CIAA_CRA, 8'b00000110); // stop timer
+
+      repeat(2) @(posedge c1m) check_port(1'b1); // check toggle output (high, must not change after stop)
+
+      // Test 3: Stop mid-count
+
+      cia_write_cycle(CIAA_TA_LO, 8'd10); // load 10 in talo
+      cia_write_cycle(CIAA_CRA, 8'b00010111); // start timer with force load
+
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd10);
+      @(negedge c1m) check_counter(16'd10);
+      @(negedge c1m) check_counter(16'd9);
+      @(negedge c1m) check_counter(16'd8);
+
+      cia_write_cycle(CIAA_CRA, 8'b00000110); // stop timer
+
+      check_counter(16'd7);
+
+      // Test 4: Fast pulse when latch == 0
+      cia_write_cycle(CIAA_EXT, 8'b00000110); // set CIA A extensions (fast pulse and fast reload)
+      cia_write_cycle(CIAA_TA_LO, 8'd00); // load 0 in talo
+      cia_write_cycle(CIAA_CRA, 8'b00010011); // start timer with force load (with pulse)
+
+      @(posedge ciaa.ciai.ta.run_s[1])
+
+       // expect consecutive underflows with half-cycle pulses
+       repeat(4)
+       begin
+         @(posedge c1m);
+         check_underflow(1'b1);
+
+         @(negedge c1m);
+         @(negedge clk_s[0]);
+         check_port(1'b1);
+
+         @(posedge c1m);
+         @(negedge clk_s[0]);
+         check_port(1'b0);
+       end
+
+       cia_write_cycle(CIAA_CRA, 8'b00000110); // stop timer
+
+      // disable all extensions (vanilla CIA)
+      cia_write_cycle(CIAA_EXT, 8'b00000000); // set CIA A extensions
+
+      // Test 5: Force load while running
+      cia_write_cycle(CIAA_TA_LO, 8'd7); // load 7 in talo
+      cia_write_cycle(CIAA_CRA, 8'b00010110); // force load (without start)
+      cia_write_cycle(CIAA_TA_LO, 8'd9); // load 8 in talo
+      cia_write_cycle(CIAA_CRA, 8'b00000111); // start timer
+
+      @(posedge ciaa.ciai.ta.run_s[1]) check_counter(16'd7);
+      @(negedge c1m) check_counter(16'd6);
+      @(negedge c1m) check_counter(16'd5);
+
+      cia_write_cycle(CIAA_CRA, 8'b00010111); // force load (already started)
+
+      @(negedge ciaa.ciai.ta.fld_i);  // wait for counter to load
+      check_counter(16'd9);
+      cia_write_cycle(CIAA_CRA, 8'b00000110); // stop timer
+
     end
   endtask
 
   task cia_test_rst();
     begin
+      // ports A/B can't be tested there
       // check powerup and reset state
       cia_read_check(CIAA_DDRA, 8'b00000000);
       cia_read_check(CIAA_DDRB, 8'b00000000);
@@ -242,14 +440,12 @@ module cia_internal_tb;
       cia_read_check(CIAB_DDRA, 8'b10101010);
       cia_write_cycle(CIAA_PRA, 8'b11111111);
       cia_write_cycle(CIAB_PRA, 8'b00000000);
-      @(posedge clk); // first stage sync
-      @(posedge clk); // second stage sync
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_read_check(CIAA_PRA, 8'b01010101);
       cia_read_check(CIAB_PRA, 8'b01010101);
       cia_write_cycle(CIAA_PRA, 8'b00000000);
       cia_write_cycle(CIAB_PRA, 8'b11111111);
-      @(posedge clk); // first stage sync
-      @(posedge clk); // second stage sync
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_read_check(CIAA_PRA, 8'b10101010);
       cia_read_check(CIAB_PRA, 8'b10101010);
     end
@@ -263,25 +459,186 @@ module cia_internal_tb;
       cia_write_cycle(CIAB_DDRB, 8'b10101010);
       cia_read_check(CIAB_DDRB, 8'b10101010);
       cia_write_cycle(CIAB_PRB, 8'b00000000);
-      cia_write_cycle(CIAA_PRB, 8'b11111111);
+      cia_write_cycle(CIAA_PRB, 8'b11111111); // pc from CIA B goes low during this cycle
+      @(posedge c1m) eoc();  // wait for flag to be settled (on cycle after read/write)
       cia_read_check(CIAA_ICR, 8'b00010000); // check flag interrupt occured
-      @(posedge clk); // first stage sync
-      @(posedge clk); // second stage sync
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_write_cycle(CIAA_ICR, 8'b10010000); // set flag interrupt
       cia_read_check(CIAB_PRB, 8'b01010101);
       cia_read_check(CIAA_PRB, 8'b01010101);
-      @(negedge clk); // wait one more cycle for interrupt propagation
+      @(posedge c1m) eoc();  // wait for flag to be settled (on cycle after read/write)
       cia_read_check(CIAA_ICR, 8'b10010000); // check flag interrupt occured (with ir flag)
       cia_write_cycle(CIAB_PRB, 8'b11111111);
       cia_write_cycle(CIAA_PRB, 8'b00000000);
-      @(negedge clk); // wait one more cycle for interrupt propagation
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_write_cycle(CIAA_ICR, 8'b00010000); // clear flag interrupt (with pending interrupt)
       cia_read_check(CIAA_ICR, 8'b00010000); // check flag interrupt occured (without ir flag)
-      @(posedge clk); // first stage sync
-      @(posedge clk); // second stage sync
+      @(posedge c1m) eoc();  // wait metastable sync
       cia_read_check(CIAB_PRB, 8'b10101010);
       cia_read_check(CIAA_PRB, 8'b10101010);
+      @(posedge c1m) eoc();  // wait for flag to be settled (on cycle after read/write)
       cia_read_check(CIAA_ICR, 8'b00010000); // check flag interrupt occured
+    end
+  endtask
+
+  task cia_test_serial_a_to_b(input [7:0] data, input fast);
+    begin
+      cia_write_cycle(CIAA_EXT, { 5'b00000, fast, 1'b0, fast}); // set CIA A extensions
+      cia_write_cycle(CIAB_EXT, { 5'b00000, fast, 1'b0, fast}); // set CIA B extensions
+      cia_write_cycle(CIAA_CRA, 8'b01000000); // set CIA A for serial output
+      @(posedge c1m) eoc();  // wait cnt to be high
+      cia_write_cycle(CIAB_CRA, 8'b00000000); // set CIA A for serial input
+      cia_write_cycle(CIAA_SDR, data); // set data to be transmited
+      cia_write_cycle(CIAA_TA_LO, 8'b00000000);
+      cia_write_cycle(CIAA_TA_HI, 8'b00000000);
+      cia_read_cycle(CIAA_ICR);
+      cia_read_cycle(CIAB_ICR);
+      cia_write_cycle(CIAA_CRA, 8'b01010001); // start timer
+
+      @(negedge ciaa.ciai.serial.cnt_o); // wait for first bit to be out
+      cia_write_cycle(CIAA_SDR, ~data); // set data to be transmited (second word)
+
+      @(negedge ciaa.ciai.serial.spo_o); // await for serial interrupt (output)
+      cia_read_check(CIAA_ICR, 8'b00001001); // check serial interrupt
+
+      @(negedge ciab.ciai.serial.spi_o); // await for serial interrupt (input)
+      cia_read_check(CIAB_ICR, 8'b00001000); // check serial interrupt
+
+      cia_read_check(CIAB_SDR, data); // check received data
+
+      @(negedge ciaa.ciai.serial.spo_o); // await for serial interrupt (output)
+      cia_read_check(CIAA_ICR, 8'b00001001); // check serial interrupt
+
+      @(negedge ciab.ciai.serial.spi_o); // await for serial interrupt (input)
+      cia_read_check(CIAB_ICR, 8'b00001000); // check serial interrupt
+
+      @(negedge c1m) eoc(); // await for sdr to be updated
+      cia_read_check(CIAB_SDR, ~data); // check received data
+
+      cia_write_cycle(CIAA_CRA, 8'b01010000); // stop timer
+    end
+  endtask
+
+  task cia_test_serial_b_to_a(input [7:0] data, input fast);
+    begin
+      cia_write_cycle(CIAB_EXT, { 5'b00000, fast, 1'b0, fast}); // set CIA A extensions
+      cia_write_cycle(CIAA_EXT, { 5'b00000, fast, 1'b0, fast}); // set CIA B extensions
+      cia_write_cycle(CIAB_CRA, 8'b01000000); // set CIA A for serial output
+      @(posedge c1m) eoc();  // wait cnt to be high
+      cia_write_cycle(CIAA_CRA, 8'b00000000); // set CIA A for serial input
+      cia_write_cycle(CIAB_SDR, data); // set data to be transmited
+      cia_write_cycle(CIAB_TA_LO, 8'b00000000);
+      cia_write_cycle(CIAB_TA_HI, 8'b00000000);
+      cia_read_cycle(CIAA_ICR);
+      cia_read_cycle(CIAB_ICR);
+      cia_write_cycle(CIAB_CRA, 8'b01010001); // start timer
+
+      @(negedge ciab.ciai.serial.cnt_o); // wait for first bit to be out
+      cia_write_cycle(CIAB_SDR, ~data); // set data to be transmited (second word)
+
+      @(negedge ciab.ciai.serial.spo_o); // await for serial interrupt (output)
+      cia_read_check(CIAB_ICR, 8'b00001001); // check serial interrupt
+
+      @(negedge ciaa.ciai.serial.spi_o); // await for serial interrupt (input)
+      cia_read_check(CIAA_ICR, 8'b00001000); // check serial interrupt
+
+      cia_read_check(CIAA_SDR, data); // check received data
+
+      @(negedge ciab.ciai.serial.spo_o); // await for serial interrupt (output)
+      cia_read_check(CIAB_ICR, 8'b00001001); // check serial interrupt
+
+      @(negedge ciaa.ciai.serial.spi_o); // await for serial interrupt (input)
+      cia_read_check(CIAA_ICR, 8'b00001000); // check serial interrupt
+
+      @(negedge c1m) eoc(); // await for sdr to be updated
+      cia_read_check(CIAA_SDR, ~data); // check received data
+
+      cia_write_cycle(CIAB_CRA, 8'b01010000); // stop timer
+    end
+  endtask
+
+  task cia_test_tod();
+    begin
+      // enable tod pin
+      tod_drv = 1'b0;
+      tod_ovr = 1'b1;
+
+      // clear interrupts
+      cia_read_cycle(CIAA_ICR);
+
+      // Test 1 : Basic counting
+
+      // set tod to 0x10
+      cia_write_tod(24'h000010);
+
+      repeat(5) pulse_tod();
+
+      cia_read_check(CIAA_TOD_LOW, 8'h15);
+
+      // Test 2 : Freeze and read the latch
+
+      cia_read_check(CIAA_TOD_HI, 8'h00); // also freeze the latch
+
+      repeat(5) pulse_tod();
+
+      cia_read_check(CIAA_TOD_LOW, 8'h15); // must still return 15 (and unfreeze)
+      cia_read_check(CIAA_TOD_HI, 8'h00); // also freeze the latch
+      cia_read_check(CIAA_TOD_LOW, 8'h1a); // must return 1a
+
+      // Test 3 : Stop / Restart the TOD
+
+      cia_write_cycle(CIAA_TOD_HI, 8'b00000000); // stop the tod
+
+      // pulse it
+      repeat(5) pulse_tod();
+
+      cia_read_check(CIAA_TOD_LOW, 8'h1a); // must return 1a
+
+      cia_write_cycle(CIAA_TOD_LOW, 8'h20); // restart the tod as 0x20
+
+      // pulse it again
+      repeat(5) pulse_tod();
+
+      cia_read_check(CIAA_TOD_LOW, 8'h25); // must return 25
+
+      // Test 4 : tod alrm
+
+      
+      cia_write_alrm(24'h00002a);
+
+      // pulse to 0x2a
+      repeat(5) pulse_tod();
+
+      cia_read_check(CIAA_ICR, 8'b00000100); // must return alrm
+      cia_read_check(CIAA_TOD_LOW, 8'h2a); // must return 2a
+
+      cia_write_cycle(CIAA_TOD_HI, 8'b00000000); // stop the tod
+
+      // disable tod pin
+      tod_drv = 1'b0;
+      tod_ovr = 1'b0;
+    end
+  endtask
+
+  task cia_write_cycle(
+      input [4:0] adr_i,
+      input [7:0] dat_i
+    );
+    begin
+      // go to end of current cycle
+      eoc();
+
+      cia_dat_i = dat_i;
+      cia_adr = adr_i[3:0];
+      cia_we = 1;
+      { ciaa_sel, ciab_sel } = { ~adr_i[4], adr_i[4] };
+
+      @(negedge c1m);
+
+      eoc();
+      { ciaa_sel, ciab_sel } = 2'b0;
+      cia_adr = 4'b0;
+      cia_we = 0;
     end
   endtask
 
@@ -289,15 +646,18 @@ module cia_internal_tb;
       input [4:0] adr_i
     );
     begin
-      if (~clk)
-        @(posedge clk);
+      // go to end of current cycle
+      eoc();
+
       cia_adr = adr_i[3:0];
       cia_we = 0;
-      #25 { ciaa_sel, ciab_sel } = { ~adr_i[4], adr_i[4] };
-      @(negedge clk);
-      cia_dat_r = cia_dat;
-      #25 { ciaa_sel, ciab_sel } = 2'b0;
-      //cia_adr[3:0] = 4'bx;
+      { ciaa_sel, ciab_sel } = { ~adr_i[4], adr_i[4] };
+
+      @(negedge c1m) cia_dat_r = cia_dat;
+
+      eoc();
+      { ciaa_sel, ciab_sel } = 2'b0;
+      cia_adr = 4'b0;
       cia_we = 0;
     end
   endtask
@@ -309,44 +669,174 @@ module cia_internal_tb;
     begin
       cia_read_cycle(adr_i);
 
-      if (cia_dat_r != dat_i) begin
+      if (cia_dat_r != dat_i)
+      begin
         $display("read error : %t address 0x%h got %b expected %b", $time, adr_i, cia_dat_r, dat_i);
       end
     end
   endtask
 
-  task cia_write_cycle(
-      input [4:0] adr_i,
-      input [7:0] dat_i
-    );
+  // Helper task: read counter (timer A)
+  task check_counter(input [15:0] expected);
+    reg [15:0] actual;
     begin
-      if (~clk)
-        @(posedge clk);
-      cia_dat_i = dat_i;
-      cia_adr = adr_i[3:0];
-      cia_we = 1;
-      #25 { ciaa_sel, ciab_sel } = { ~adr_i[4], adr_i[4] };
-      @(negedge clk);
-      #25 { ciaa_sel, ciab_sel } = 2'b0;
-      //cia_adr[3:0] = 4'bx;
-      //cia_dat_i = 8'bx;
-      cia_we = 0;
+      actual = ciaa.ciai.ta.cnt_o;
+      if (actual !== expected)
+      begin
+        $display("ERROR @%t: Counter mismatch! Expected=%04h, Got=%04h",
+                 $time, expected, actual);
+      end
+      else
+      begin
+        $display("OK @%t: Counter=%04h", $time, actual);
+      end
     end
   endtask
 
-  initial begin
-    $dumpfile ("cia_sim.vcd");
-    $dumpvars;
+  // Helper task: check output pulse (timer A)
+  task check_pulse(input expected);
+    reg actual;
+    begin
+      actual = ciaa.ciai.ta.pls_o;
+      if (actual !== expected)
+      begin
+        $display("ERROR @%t: Pulse mismatch! Expected=%b, Got=%b",
+                 $time, expected, actual);
+      end
+      else
+      begin
+        $display("OK @%t: Pulse=%b", $time, actual);
+      end
+    end
+  endtask
+
+  // Helper task: check port output (timer A)
+  task check_port(input expected);
+    reg actual;
+    begin
+      actual = ciaa.ciai.ta.prb_o;
+      if (actual !== expected)
+      begin
+        $display("ERROR @%t: Port mismatch! Expected=%b, Got=%b",
+                 $time, expected, actual);
+      end
+      else
+      begin
+        $display("OK @%t: Port=%b", $time, actual);
+      end
+    end
+  endtask
+
+  // Helper task: check underflow output (timer A)
+  task check_underflow(input expected);
+    reg actual;
+    begin
+      actual = ciaa.ciai.ta.unfl_o;
+      if (actual !== expected)
+      begin
+        $display("ERROR @%t: Underflow mismatch! Expected=%b, Got=%b",
+                 $time, expected, actual);
+      end
+      else
+      begin
+        $display("OK @%t: Underflow=%b", $time, actual);
+      end
+    end
+  endtask
+
+  task pulse_tod();
+    begin
+      eoc();
+      // generate tod pulse
+      @(negedge c1m) tod_drv = 1'b1;
+      // first stage sync passed (on posedge)
+      @(negedge c1m) tod_drv = 1'b0;
+      // second stage sync passed (on posedge, pulse generated)
+      repeat(2) @(negedge c1m);
+      eoc();
+    end
+  endtask
+
+  task cia_write_tod(
+      input [23:0] value
+    );
+    begin
+      cia_write_cycle(CIAA_TOD_HI, value[23:16]);
+      cia_write_cycle(CIAA_TOD_MID, value[15:8]);
+      cia_write_cycle(CIAA_TOD_LOW, value[7:0]);
+    end
+  endtask
+
+  task cia_write_alrm(
+      input [23:0] value
+    );
+    begin
+      // select ALRM register using CRB
+      cia_write_cycle(CIAA_CRB, { 1'b1, ciaa.ciai.decoder.crb_i[6:0] });
+      cia_write_cycle(CIAA_TOD_HI, value[23:16]);
+      cia_write_cycle(CIAA_TOD_MID, value[15:8]);
+      cia_write_cycle(CIAA_TOD_LOW, value[7:0]);
+      cia_write_cycle(CIAA_CRB, { 1'b0, ciaa.ciai.decoder.crb_i[6:0] });
+    end
+  endtask
+
+  // Helper task: pulse reset
+  task pulse_reset();
+    begin
+      // go to end of current cycle
+      eoc();
+
+      rst_i = 1'b1;
+
+      // consume 1 full cycle
+      @(posedge c1m) eoc();
+
+      rst_i = 1'b0;
+    end
+  endtask
+
+  // Helper task: go to end of cycle
+  task eoc();
+    begin
+      case(clk_s)
+        2'd0,2'd1:
+        begin
+          @(negedge clk_s[0]);
+          @(posedge clk_s[0]);
+        end
+        2'd2:
+        begin
+          @(posedge clk_s[0]);
+        end
+      endcase
+    end
+  endtask
+
+  // Clock generation (1MHz phi2)
+  initial
+  begin
+    clk_s = 0;
+    c1m = 0;
+    forever
+      #250 clk_s = clk_s + 1; // 1us period = 2MHz
+  end
+
+  always @(posedge c2m)
+  begin
+    // divide by 2 for 1MHz period
+    c1m = clk_s[1];
   end
 
   initial
-    #200000 $finish;
-
-  // clocks generator
-  initial begin
-    clk = 0;
+  begin
+    rst_i = 0;
   end
 
-  always
-    #50 clk = ~clk;
+  // Timeout watchdog
+  initial
+  begin
+    #600000; // 100us timeout
+    $display("ERROR: Simulation timeout!");
+    $finish;
+  end
 endmodule

--- a/cia/cia_decoder.v
+++ b/cia/cia_decoder.v
@@ -1,0 +1,143 @@
+/*
+ * CIA 8520 Address Decoder and Read Multiplexer
+ * 
+ * Combinatorial module that decodes the 4-bit register address (RS3-RS0)
+ * and routes data between the CIA's internal registers and the data bus.
+ * 
+ * Design notes:
+ * - Pure combinatorial logic (no clock, no state)
+ * - One-hot decoding for address selection (adr_sel)
+ * - Generates individual strobe signals for each register
+ * - Multiplexes 16 input registers onto single 8-bit output bus
+ * 
+ * Register Map (MOS 8520 compatible):
+ *   $0 (0x0) - PRA     : Port A data register
+ *   $1 (0x1) - PRB     : Port B data register
+ *   $2 (0x2) - DDRA    : Port A data direction (0=input, 1=output)
+ *   $3 (0x3) - DDRB    : Port B data direction
+ *   $4 (0x4) - TA_LO   : Timer A low byte
+ *   $5 (0x5) - TA_HI   : Timer A high byte
+ *   $6 (0x6) - TB_LO   : Timer B low byte
+ *   $7 (0x7) - TB_HI   : Timer B high byte
+ *   $8 (0x8) - TOD_LO  : Time of day counter LSB
+ *   $9 (0x9) - TOD_MID : Time of day counter
+ *   $A (0xA) - TOD_HI  : Time of day counter MSB
+ *   $B (0xB) - EXT     : Extension register
+ *   $C (0xC) - SDR     : Serial data register
+ *   $D (0xD) - ICR     : Interrupt control register
+ *   $E (0xE) - CRA     : Control register A
+ *   $F (0xF) - CRB     : Control register B
+ * 
+ * Usage:
+ * - Address strobe outputs (pra_o, prb_o, etc.) are used by parent module
+ *   to detect register access and trigger side effects (e.g., PC pulse on PRB access,
+ *   TOD latch on TOD_HI read, timer reload on TA_HI/TB_HI write)
+ * - Data output (dat_o) provides the read value for the selected register
+ * - All outputs are valid within the same combinatorial path as adr_i
+ * 
+ * Implementation:
+ * - One-hot decode using shift: 16'b1 << adr_i (synthesizes to simple logic)
+ * - Read mux using OR of masked inputs (synthesizes to efficient mux tree)
+ * - No critical paths: fully combinatorial, no feedback
+ */
+module cia_decoder(
+    input  [3:0] adr_i, // address selector input
+
+    // input from other modules to be set in dat_o
+    input  [7:0] pra_i,
+    input  [7:0] prb_i,
+    input  [7:0] ddra_i,
+    input  [7:0] ddrb_i,
+    input  [7:0] talo_i,
+    input  [7:0] tahi_i,
+    input  [7:0] tblo_i,
+    input  [7:0] tbhi_i,
+    input  [7:0] todlo_i,
+    input  [7:0] todmid_i,
+    input  [7:0] todhi_i,
+    input  [7:0] ext_i,
+    input  [7:0] sdr_i,
+    input  [7:0] icr_i,
+    input  [7:0] cra_i,
+    input  [7:0] crb_i,
+
+    // selected output
+    output [7:0] dat_o,
+
+    // output selected address as strobe
+    output pra_o,
+    output prb_o,
+    output ddra_o,
+    output ddrb_o,
+    output talo_o,
+    output tahi_o,
+    output tblo_o,
+    output tbhi_o,
+    output todlo_o,
+    output todmid_o,
+    output todhi_o,
+    output ext_o,
+    output sdr_o,
+    output icr_o,
+    output cra_o,
+    output crb_o
+  );
+
+  // register addresses (constants)
+  localparam [3:0] REG_PRA     = 4'h0;
+  localparam [3:0] REG_PRB     = 4'h1;
+  localparam [3:0] REG_DDRA    = 4'h2;
+  localparam [3:0] REG_DDRB    = 4'h3;
+  localparam [3:0] REG_TA_LO   = 4'h4;
+  localparam [3:0] REG_TA_HI   = 4'h5;
+  localparam [3:0] REG_TB_LO   = 4'h6;
+  localparam [3:0] REG_TB_HI   = 4'h7;
+  localparam [3:0] REG_TOD_LOW = 4'h8;
+  localparam [3:0] REG_TOD_MID = 4'h9;
+  localparam [3:0] REG_TOD_HI  = 4'ha;
+  localparam [3:0] REG_EXT     = 4'hb;
+  localparam [3:0] REG_SDR     = 4'hc;
+  localparam [3:0] REG_ICR     = 4'hd;
+  localparam [3:0] REG_CRA     = 4'he;
+  localparam [3:0] REG_CRB     = 4'hf;
+
+  // barrel shifter
+  wire [15:0] adr_sel = 16'b1 << adr_i;
+
+  // address comparators
+  assign pra_o    = adr_sel[REG_PRA];
+  assign prb_o    = adr_sel[REG_PRB];
+  assign ddra_o   = adr_sel[REG_DDRA];
+  assign ddrb_o   = adr_sel[REG_DDRB];
+  assign talo_o   = adr_sel[REG_TA_LO];
+  assign tahi_o   = adr_sel[REG_TA_HI];
+  assign tblo_o   = adr_sel[REG_TB_LO];
+  assign tbhi_o   = adr_sel[REG_TB_HI];
+  assign todlo_o  = adr_sel[REG_TOD_LOW];
+  assign todmid_o = adr_sel[REG_TOD_MID];
+  assign todhi_o  = adr_sel[REG_TOD_HI];
+  assign ext_o    = adr_sel[REG_EXT];
+  assign sdr_o    = adr_sel[REG_SDR];
+  assign icr_o    = adr_sel[REG_ICR];
+  assign cra_o    = adr_sel[REG_CRA];
+  assign crb_o    = adr_sel[REG_CRB];
+
+  // module output
+  assign dat_o =
+         ({8{pra_o}}   & pra_i)   |
+         ({8{prb_o}}   & prb_i)   |
+         ({8{ddra_o}}  & ddra_i)  |
+         ({8{ddrb_o}}  & ddrb_i)  |
+         ({8{talo_o}}  & talo_i)  |
+         ({8{tahi_o}}  & tahi_i)  |
+         ({8{tblo_o}}  & tblo_i)  |
+         ({8{tbhi_o}}  & tbhi_i)  |
+         ({8{todlo_o}} & todlo_i) |
+         ({8{todmid_o}}& todmid_i)|
+         ({8{todhi_o}} & todhi_i) |
+         ({8{ext_o}}   & ext_i)   |
+         ({8{sdr_o}}   & sdr_i)   |
+         ({8{icr_o}}   & icr_i)   |
+         ({8{cra_o}}   & cra_i)   |
+         ({8{crb_o}}   & crb_i);
+endmodule

--- a/cia/cia_handshake.v
+++ b/cia/cia_handshake.v
@@ -1,0 +1,45 @@
+/*
+ * CIA 8520 Handshake module
+ * Handles FLAG input synchronization and PC output generation
+ * 
+ * Design notes:
+ * - FLAG input is synchronized through 3-stage pipeline
+ * - Flag pulse (pls_o) is generated on negedge for interrupt logic
+ * - PC will go low on 1 cycle after a  port B  access
+ */
+module cia_handshake(
+    input clk_i, // master clock (phi2)
+
+    input prb_i, // strobe for PRB write
+    input flg_ni, // inverted external flag pin
+
+    // outputs
+    output     pls_o, // flag pulse for interrupts
+    output reg pc_no   // pc output
+  );
+
+  // registers
+  reg [2:0] flg_s; // flag sync register
+  reg       pc_s;  // pc sync register
+
+  // flag pulse generator
+  assign pls_o = ~flg_s[2] & flg_s[1];
+
+  always @(posedge clk_i)
+  begin
+    // start flag signal sync
+    flg_s[0] <= ~flg_ni;
+  end
+
+  always @(negedge clk_i)
+  begin
+    // end flag signal sync and trigger pulse for 1 clock cycle
+    { flg_s[2], flg_s[1] } <= { flg_s[1], flg_s[0] };
+  end
+
+  always @(negedge clk_i)
+  begin
+    // trigger PC low for 1 clock cycle following a read or write to PRB
+    { pc_no, pc_s } <= { ~pc_s, prb_i};
+  end
+endmodule

--- a/cia/cia_interrupts.v
+++ b/cia/cia_interrupts.v
@@ -1,0 +1,75 @@
+/*
+ * CIA 8520 IRQ module
+ * Handles interrupt flag accumulation and IRQ generation
+ * 
+ * Design notes:
+ * - Interrupt flags are available on posedge phi2
+ * - Interrupt flags are cleared on falling edge of clr_i
+ * - IRQ output (irq_o) updates on posedge phi2 (parent module will handle IRQ delay to negedge)
+ * - Parent module handles ICR register interface and mask management
+ * 
+ * Interrupt sources (bit positions):
+ * - bit 0: Timer A underflow
+ * - bit 1: Timer B underflow
+ * - bit 2: TOD alarm
+ * - bit 3: Serial port
+ * - bit 4: FLAG pin
+ */
+module cia_irq(
+    input clk_i,   // master clock
+    input rst_i,   // reset input (active high)
+
+    // interrupt source pulses (active on posedge)
+    input ta_i,    // timer A underflow
+    input tb_i,    // timer B underflow
+    input alrm_i,  // TOD alarm
+    input sp_i,    // serial port
+    input flg_i,   // FLAG pin
+
+    // control
+    input [4:0] msk_i,  // interrupt mask from parent
+    input       clr_i,  // clear strobe (on ICR read)
+
+    // outputs
+    output reg [4:0] icr_o, // interrupt flags
+    output           irq_o  // IRQ active flag (active high)
+  );
+
+  // clr_i edge detection
+  reg clr_r;
+  wire clr_pls = clr_r & ~clr_i; // falling edge detector
+
+  // masked interrupt flags
+  wire [4:0] irq_w = icr_o & msk_i;
+
+  // IRQ active if any masked interrupt is set
+  assign irq_o = |irq_w;
+
+  // clr_i synchronization and edge detection
+  always @(posedge clk_i)
+  begin
+    if (rst_i)
+      clr_r <= 1'b0;
+    else
+      clr_r <= clr_i;
+  end
+
+  // interrupt flag management (posedge)
+  always @(posedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      icr_o <= 5'b0;
+    end
+    else if (clr_pls)
+    begin
+      // clear flags but keep new interrupts occurring in same cycle
+      icr_o <= { flg_i, sp_i, alrm_i, tb_i, ta_i };
+    end
+    else
+    begin
+      // accumulate interrupt flags
+      icr_o <= icr_o | { flg_i, sp_i, alrm_i, tb_i, ta_i };
+    end
+  end
+endmodule

--- a/cia/cia_serial.v
+++ b/cia/cia_serial.v
@@ -1,0 +1,204 @@
+/*
+ * CIA 8520 Serial Port Module
+ * This module implements the bidirectional synchronous serial shift register
+ * found in the MOS 8520. It handles both internal (Timer A) and external 
+ * (CNT pin) clocking.
+ *
+ * Design Architecture:
+ * - Shift Register: A 9-bit register is used. 
+ * - In both Input and Output a stop bit is used to detect transmission has ended
+ * - one clock cycle is required to setup the port in input or output mode.
+ *
+ * Sampling Coherency:
+ *   The Serial Port input (sp_i) is sampled by the parent beside cnt_i.
+ *
+ * Clocking Phase:
+ * - Internal state and shifting occur on the POSITIVE edge of clk_i.
+ * - External output pins (cnt_o and sp_o) update on the NEGATIVE edge 
+ * to ensure stable setup time for external hardware.
+ *
+ * Extension Features:
+ * - Lookahead restart: In input mode, the module anticipates the 8th bit 
+ * to remove "dead cycles" between transmissions.
+ *
+ * Timing:
+ * - Output Baud Rate: (up to) Half the frequency of Timer A underflows (with fast extensions enabled in parent).
+ * - Input Baud Rate: Determined by the external CNT clock frequency.
+ */
+module cia_serial(
+    input clk_i, // master clock
+    input rst_i, // reset input (active high)
+
+    input  [7:0] dat_i, // data input (when in output mode)
+    output [7:0] dat_o, // data output (when in input mode, always set to shift register contents)
+
+    // cnt clock, parent handle synchronization (shared with timers A/B)
+    input       unfl_i, // timer A underflow input (available at posedge)
+    input       cnt_i,  // synchronized cnt input (sampled and available at posedge)
+    output reg  cnt_o,  // cnt output, updated at negedge
+
+    input      sp_i, // serial input (sampled with cnt)
+    output reg sp_o, // serial output, updated at negedge
+
+    input      spmd_i, // serial mode (0= input, 1=output)
+    input      spoe_i, // output enable
+    output reg spoe_o, // output acknowledge
+
+    output     spo_o, // output data sent pulse
+    output reg spi_o  // input data ready pulse
+  );
+
+  reg [8:0] shft;
+
+  // serial input stuff
+  reg spi_rdy; // strobe to signal that serial port is ready to receive data
+
+  wire [8:0] spi_nxt = { shft[7:0], sp_i };
+  wire       spi_done = spi_nxt[8];
+
+  assign dat_o = shft[7:0];
+
+  // serial output stuff
+  reg cnt_d; // delayed cnt pin (computed at posedge for negedge)
+  reg sp_d; // delayed sp pin (computed at posedge for negedge)
+
+  reg  spo_rdy; // strobe to signal that serial port is ready to send data
+  wire spo_pnd = spoe_i ^ spoe_o; // pending output data
+
+  wire [8:0] spo_new = { dat_i, 1'b1 };
+  wire [8:0] spo_nxt = { shft[7:0], 1'b0 };
+
+  // spo_done indicates that the *next shift event* will transmit the final bit.
+  // The next shift may occur several phi2 cycles later (Timer A driven).
+  wire spo_done = ~(|spo_nxt[7:0]); // output data has been sent
+
+  assign spo_o = spo_s[0] & ~spo_s[1];
+  reg [1:0] spo_s;
+
+  // always update output interrupt pulses
+  always @(posedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      spo_s <= 2'b11;
+      spi_o <= 1'b0;
+    end
+    else
+    begin
+      spi_o <= spi_done & ~spmd_i & cnt_i;
+      spo_s <= {spo_s[0], spo_rdy ? spo_done : 1'b1};
+    end
+  end
+
+  // initialize shift register for input or output
+  always @(posedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      shft <= 9'b0;
+      spi_rdy <= 1'b0;
+      spo_rdy <= 1'b0;
+
+      cnt_d <= 1'b1; // cnt_d is always reset to '1'
+      sp_d <= 1'b0;
+
+      spoe_o <= 1'b0;
+    end
+    else
+    begin
+      if (spmd_i)
+      begin
+        spi_rdy <= 1'b0;
+
+        if (spo_rdy)
+        begin
+          if (unfl_i)
+          begin
+            if (cnt_d)
+            begin
+              if (spo_done)
+              begin
+                if (spo_pnd)
+                begin
+                  // data is pending, begin a new transmission
+                  shft <= spo_new;
+                  spoe_o <= spoe_i;
+
+                  cnt_d <= ~cnt_d;
+                  sp_d <= spo_new[8];
+                end
+                else
+                begin
+                  // no pending data, set the port to idle (all zero)
+                  shft <= spo_nxt;
+                end
+              end
+              else
+              begin
+                // last case, port is not idle nor done.
+                // shift next bit and make it available to serial output pin
+                shft <= spo_nxt;
+
+                cnt_d <= ~cnt_d;
+                sp_d <= spo_nxt[8];
+              end
+            end
+            else
+            begin
+              cnt_d <= 1'b1;
+            end
+          end
+        end
+        else
+        begin
+          // initialize shift register to zero
+          shft <= 9'b000000000;
+          spo_rdy <= 1'b1;
+        end
+      end
+      else
+      begin
+        // ensure that output is disabled and cnt is high
+        spo_rdy <= 1'b0;
+        cnt_d <= 1'b1;
+
+        if (spi_rdy)
+        begin
+          if (cnt_i)
+          begin
+            // when receiving a cnt pulse, shift the buffer
+            // and restart if last bit
+            shft <= spi_nxt;
+
+            // lookahead restart: if stop bit detected in next state,
+            // restart transmission immediately (no dead cycle). The
+            // parent MUST transfer dat_o to sdr BEFORE next bit comes in.
+            spi_rdy <= ~spi_done;
+          end
+        end
+        else
+        begin
+          if (cnt_i)
+          begin
+            // handle the special case where a cnt pulse comes during serial reset
+            // This should not occur since cnt_i is a pulse and not a strobe.
+            shft <= { 8'b00000001, sp_i };
+          end
+          else
+          begin
+            // setup serial port for receiving (add the stop bit)
+            shft <= 9'b000000001;
+          end
+
+          spi_rdy <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(negedge clk_i)
+  begin
+    cnt_o <= cnt_d;
+    sp_o <= sp_d;
+  end
+endmodule

--- a/cia/cia_timer.v
+++ b/cia/cia_timer.v
@@ -1,0 +1,173 @@
+/*
+ * CIA 8520 Timer module
+ * Single timer (phi2) implementation
+ * 
+ * Design notes:
+ * - fast reload (if frle_i asserted)
+ * - when reloading the counter does not tick nor underflow
+ * - early underflow detection allow interrupt delivery at the same cycle the underflow occurs
+ * - underflow detection is the output of combinatorial used by counter logic
+ * 
+ * timing behavior:
+ * - counter (cnt_o) updates on posedge phi2
+ * - prb_o update on negedge phi2
+ * - pls_o, run_o updates on posedge phi2
+ * - unfl_o is meant to be used on phi2 posedge (early underflow detection)
+ * 
+ * PRB fast pulse (improvement over original CIA 8520 if fste_i asserted):
+ *   When latch value is zero, consecutive underflows are detected, PRB
+ *   pulse width is shortened to half phi2 period. fast pulse have a visible
+ *   only if reload delay is suppressed
+ * 
+ */
+module cia_timer(
+    input clk_i, // master clock (phi2)
+    input rst_i, // reset input (active high)
+
+    // control inputs
+    input cnt_i,  // counter tick strobe (1 = tick this phi2 cycle)
+    input omd_i,  // output mode (0=pulse, 1=toggle)
+    input str_i,  // start control from CRA/CRB (1=running, 0=stopped)
+    input fld_i,  // force load strobe (1=reload from latch)
+
+    // extended features
+    input fste_i, // enable half pulses on port B
+    input frle_i, // enable fast timer reload (no dead cycle)
+
+    // register interface
+    input      [15:0] lch_i, // timer latch (must be stable at rising phi2)
+    output reg [15:0] cnt_o, // timer counter output (updated at rising phi2)
+
+    // outputs
+    output     run_o, // timer running flag
+    output reg pls_o, // pulse output (1 phi2 period on underflow, set on posedge)
+    output     prb_o, // port output (for PB6/PB7, set on negedge)
+    output     unfl_o // signal that timer is underflowing (only valid at rising phi2)
+  );
+
+  // internal registers
+  reg [1:0] run_s;  // running status sync (for toggle reset detection)
+  reg [1:0] pls_s;  // pulse generator for PRB
+  reg       tgl_r;  // toggle output state
+  reg       fst_r;  // current prb pulse is short
+  reg       frle_d; // delay after reload (or underflow)
+
+  // tick_n waits for toggle output to be high
+  wire   tick_n = (str_i & cnt_i) & ~frle_d & ~fld_i & run_s[1]; // counter should tick this cycle
+
+  // unfl_o is asserted on the same posedge where the counter reloads,
+  // allowing same-cycle IRQ and timer chaining
+  assign unfl_o = tick_n & cnt_z; // counter will underflow on next posedge
+
+  // return timer status
+  assign run_o = |run_s; // report running until complete stop
+
+  // counter arithmetic (inverted: increment instead of decrement)
+  reg [16:0] cnt_n; // next counter value
+  reg        cnt_z; // underflow
+
+  always @(*)
+  begin
+    if (fld_i)
+      // force load resets the counter
+      cnt_n = {1'b0, lch_i};
+    else
+      cnt_n = cnt_o - tick_n;
+
+    cnt_z = cnt_n[16]; // borrow out
+  end
+
+  // compute next value for toggle output
+  reg tgl_n;
+
+  always @(*)
+  begin
+    if (run_s[0] & ~run_s[1])
+      // timer is starting, set toggle high
+      tgl_n = 1'b1;
+    else if (run_s[1])
+      // Toggle on underflow if timer still running
+      tgl_n = tgl_r ^ pls_o;
+    else
+      tgl_n = tgl_r;
+  end
+
+  // outputs
+  wire   pls_w = pls_s[0] ^ pls_s[1];   // port pulse (can be half phi2 period if timer too fast)
+  assign prb_o = omd_i ? tgl_r : pls_w; // port output
+
+  // free run assignements without reset
+
+  always @(posedge clk_i)
+  begin
+    // start run signal sync
+    run_s[0] <= str_i;
+
+    // save underflow flag for next negedge
+    pls_o <= unfl_o;
+
+    // save fast pulse mode
+    // so stopping the timer when in fast mode won't produce full pulse.
+    fst_r <= pls_o & unfl_o;
+
+    // disable next clock after a reload
+    // this only matters when clocked with phi2 (cnt_i always high)
+    frle_d <= ~frle_i & (cnt_z | fld_i);
+  end
+
+  always @(negedge clk_i)
+  begin
+    run_s[1] <= run_s[0]; // end run signal sync
+  end
+
+  // end of free run blocks
+
+  // main counter logic (on phi2 posedge)
+  always @(posedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      pls_s[0] <= 1'b0;
+      cnt_o <= 16'hffff;
+    end
+    else
+    begin
+      // update output with next counter computed value
+      cnt_o <= cnt_z ? lch_i : cnt_n[15:0];
+
+      // fast mode detection: if we underflowed in both previous and current phi2 cycle,
+      // shorten the pulse by syncing pls_s[0] (happens after counter reload above)
+      // in case of 'force load 0' prb pulse remains short.
+      if (fste_i & (fst_r | (pls_o & unfl_o)))
+      begin
+        pls_s[0] <= pls_s[1];
+      end
+    end
+  end
+
+  // underflow pulse (negedge)
+  always @(negedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      pls_s[1] <= 1'b0;
+    end
+    else
+    begin
+      pls_s[1] <= pls_o ^ pls_s[0]; // generate pulse for PRB
+    end
+  end
+
+  // toggle output (negedge)
+  always @(negedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      tgl_r <= 1'b1;
+    end
+    else
+    begin
+      tgl_r <= tgl_n;
+    end
+  end
+endmodule

--- a/cia/cia_tod.v
+++ b/cia/cia_tod.v
@@ -1,0 +1,108 @@
+/*
+ * CIA 8520 TOD helper module
+ * 
+ * The real TOD workd with clk_i / 4. This is not applied
+ *
+ *
+ * Protocol with parent:
+ * - Module asserts cnt_o on posedge to request increment
+ * - Parent increments count_i on negedge (if no bus write)
+ * - Parent asserts cnt_i on negedge when incrementing tod
+ * - Module compares alarm on next posedge when cnt_i is asserted
+ * 
+ * Write sequence (from CIA spec):
+ * - ANY write to TOD stops counting
+ * - Clock restarts only after write to LSB (TOD_LO)
+ * 
+ * Read sequence (from CIA spec):
+ * - Read MSB (TOD_HI) latches all registers
+ * - Latch stays frozen until read of LSB (TOD_LO)
+ * - TOD continues counting while latched
+ */
+module cia_tod(
+    input clk_i, // master clock
+    input rst_i, // reset input (active high)
+
+    input tod_i, // tod count input (from external CIA pin)
+
+    // bus strobes relayed from parent
+    input sel_i, // chip select
+    input we_i,  // write enable
+
+    // input from parent address decoder.
+    input sel_alrm_i,  // select alrm for writes
+    input sel_todlo_i, // selected tod lsb
+    input sel_todmi_i,
+    input sel_todhi_i, // selected tod msb
+
+    // tod counters
+    input      [23:0] alrm_i,  // parent alrm register
+    input      [23:0] count_i, // parent tod count (from register)
+    output reg [23:0] latch_o, // output tod latch
+
+    // tod counter control
+    output cnt_o, // indicate to parent that tod should be incremented on next negedge
+    input  cnt_i, // parent did increment tod count on last negedge, check alrm
+    output pls_o  // tod alrm pulse for IRQs
+  );
+
+  // tod synchronization
+  reg [2:0] tod_s;
+
+  wire tod_pls = ~tod_s[2] & tod_s[1];
+
+  always @(posedge clk_i)
+  begin
+    // start tod signal sync (on posedge)
+    tod_s[0] <= tod_i;
+
+    // since we need to generate a tod pulse on posedge, there is no need
+    // for dual edge sync like in timer A / B
+
+    // end tod signal sync and trigger pulse for 1 clock cycle
+    { tod_s[2:1] } <= { tod_s[1:0] };
+  end
+
+  reg tod_latch_e; // tod latch enable (active high)
+  reg tod_count_e; // tod count enable (active high)
+
+  // handle enable/disable of latch and count
+  always @(negedge clk_i)
+  begin
+    if (rst_i)
+    begin
+      tod_latch_e <= 1'b0;
+      tod_count_e <= 1'b0; // tod is not running after reset
+    end
+    else if (sel_i)
+    begin
+      if (~we_i)
+      begin
+        // latch register when reading tod_hi
+        // unlatch register when reading tod low
+        tod_latch_e <= (tod_latch_e | sel_todhi_i) & ~sel_todlo_i;
+      end
+      else if (~sel_alrm_i)
+      begin
+        // Write to TOD: any write stops, LSB write restarts
+        tod_count_e <= sel_todlo_i;  // 1 if writing lo, 0 otherwise
+      end
+    end
+  end
+
+  // latch_o is used by the parent for bus output (free run)
+  // updates when latch is disabled
+  always @(posedge clk_i)
+  begin
+    if (~tod_latch_e)
+      latch_o <= count_i;
+  end
+
+  // signals the parent that it can increment the tod counter
+  // NOTE: even if cnt_o can count, the parent may not increment the tod
+  // (in case a bus write is writing to the tod)
+  assign cnt_o = tod_pls & tod_count_e;
+
+  // combinatorial alarm check - allows interrupt one cycle earlier
+  assign pls_o = cnt_i & (alrm_i == count_i);
+endmodule


### PR DESCRIPTION
I've added more tests to the bench to ensure that main features are working.
Also checked the Chip dissection.

Fixed some bugs and disabled extended features so it can be used as a replacement chip.
Using this in an FPGA will likely require external electronic to correctly handle bit per bit bidirectional shift (5v tolerant as input, 5v as output).

The decoder has been rewritten to use less logic (found out that synthesis was generating 2 comparators for each register in the previous version).
The serial has also been rewritten to avoid using counters (replaced by simple shift reg), and it does not use separate registers for input/output. drawback is that you need one extra cycle after changing SP mode (this should not be an issue).

Did make a testbench and checked synthesis but no smoke test against physical hardware.
